### PR TITLE
[Refactor] auth&member 도메인 리팩토링

### DIFF
--- a/gradlew
+++ b/gradlew
@@ -207,7 +207,7 @@ DEFAULT_JVM_OPTS='"-Xmx64m" "-Xms64m"'
 # Collect all arguments for the java command:
 #   * DEFAULT_JVM_OPTS, JAVA_OPTS, and optsEnvironmentVar are not allowed to contain shell fragments,
 #     and any embedded shellness will be escaped.
-#   * For example: A member cannot expect ${Hostname} to be expanded, as it is an environment variable and will be
+#   * For example: A user cannot expect ${Hostname} to be expanded, as it is an environment variable and will be
 #     treated as '${Hostname}' itself on the command line.
 
 set -- \

--- a/src/main/java/coffeandcommit/crema/domain/member/controller/MemberController.java
+++ b/src/main/java/coffeandcommit/crema/domain/member/controller/MemberController.java
@@ -1,6 +1,7 @@
 package coffeandcommit.crema.domain.member.controller;
 
 import coffeandcommit.crema.domain.member.dto.response.MemberResponse;
+import coffeandcommit.crema.domain.member.dto.response.MemberPublicResponse;
 import coffeandcommit.crema.domain.member.service.MemberService;
 import coffeandcommit.crema.global.common.exception.response.ApiResponse;
 import coffeandcommit.crema.global.common.exception.code.SuccessStatus;
@@ -23,31 +24,31 @@ public class MemberController {
 
     private final MemberService memberService;
 
-    @Operation(summary = "회원 정보 조회 (ID)", description = "회원 ID로 회원 정보를 조회합니다.")
+    @Operation(summary = "회원 정보 조회 (ID) - 타인용", description = "회원 ID로 공개 회원 정보를 조회합니다.")
     @SecurityRequirement(name = "JWT")
     @GetMapping("/id/{memberId}")
-    public ApiResponse<MemberResponse> getMemberById(
+    public ApiResponse<MemberPublicResponse> getMemberById(
             @Parameter(description = "회원 ID", required = true) @PathVariable String memberId) {
-        MemberResponse member = memberService.getMemberById(memberId);
+        MemberPublicResponse member = memberService.getMemberById(memberId);
         return ApiResponse.onSuccess(SuccessStatus.OK, member);
     }
 
-    @Operation(summary = "회원 정보 조회 (닉네임)", description = "닉네임으로 회원 정보를 조회합니다.")
+    @Operation(summary = "회원 정보 조회 (닉네임) - 타인용", description = "닉네임으로 공개 회원 정보를 조회합니다.")
     @SecurityRequirement(name = "JWT")
     @GetMapping("/nickname/{nickname}")
-    public ApiResponse<MemberResponse> getMemberByNickname(
+    public ApiResponse<MemberPublicResponse> getMemberByNickname(
             @Parameter(description = "닉네임", required = true) @PathVariable String nickname) {
-        MemberResponse member = memberService.getMemberByNickname(nickname);
+        MemberPublicResponse member = memberService.getMemberByNickname(nickname);
         return ApiResponse.onSuccess(SuccessStatus.OK, member);
     }
 
-    @Operation(summary = "내 정보 조회", description = "현재 로그인한 사용자의 정보를 조회합니다.")
+    @Operation(summary = "내 정보 조회", description = "현재 로그인한 사용자의 모든 정보를 조회합니다.")
     @SecurityRequirement(name = "JWT")
     @GetMapping("/me")
     public ApiResponse<MemberResponse> getMyInfo(
             @AuthenticationPrincipal UserDetails userDetails) {
         String memberId = userDetails.getUsername(); // JWT에서 member ID 추출
-        MemberResponse member = memberService.getMemberById(memberId);
+        MemberResponse member = memberService.getMyInfo(memberId);
         return ApiResponse.onSuccess(SuccessStatus.OK, member);
     }
 

--- a/src/main/java/coffeandcommit/crema/domain/member/controller/MemberController.java
+++ b/src/main/java/coffeandcommit/crema/domain/member/controller/MemberController.java
@@ -2,6 +2,7 @@ package coffeandcommit.crema.domain.member.controller;
 
 import coffeandcommit.crema.domain.member.dto.response.MemberResponse;
 import coffeandcommit.crema.domain.member.dto.response.MemberPublicResponse;
+import coffeandcommit.crema.domain.member.service.MemberProfileService;
 import coffeandcommit.crema.domain.member.service.MemberService;
 import coffeandcommit.crema.global.common.exception.response.ApiResponse;
 import coffeandcommit.crema.global.common.exception.code.SuccessStatus;
@@ -11,9 +12,11 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @Slf4j
 @RestController
@@ -23,6 +26,7 @@ import org.springframework.web.bind.annotation.*;
 public class MemberController {
 
     private final MemberService memberService;
+    private final MemberProfileService memberProfileService;
 
     @Operation(summary = "회원 정보 조회 (ID) - 타인용", description = "회원 ID로 공개 회원 정보를 조회합니다.")
     @SecurityRequirement(name = "JWT")
@@ -52,21 +56,36 @@ public class MemberController {
         return ApiResponse.onSuccess(SuccessStatus.OK, member);
     }
 
-    @Operation(summary = "내 프로필 업데이트", description = "현재 로그인한 사용자의 프로필을 업데이트합니다.")
+    @Operation(summary = "내 프로필 정보 업데이트", description = "현재 로그인한 사용자의 닉네임과 자기소개를 업데이트합니다.")
     @SecurityRequirement(name = "JWT")
-    @PutMapping("/me/profile")
-    public ApiResponse<MemberResponse> updateMyProfile(
+    @PutMapping("/me/profile/info")
+    public ApiResponse<MemberResponse> updateMyProfileInfo(
             @Parameter(description = "닉네임") @RequestParam(required = false) String nickname,
             @Parameter(description = "자기소개") @RequestParam(required = false) String description,
-            @Parameter(description = "프로필 이미지 URL") @RequestParam(required = false) String profileImageUrl,
             @AuthenticationPrincipal UserDetails userDetails) {
 
         String memberId = userDetails.getUsername(); // JWT에서 member ID 추출
 
-        MemberResponse updatedMember = memberService.updateMemberProfile(
-                memberId, nickname, description, profileImageUrl);
+        MemberResponse updatedMember = memberService.updateMemberProfileInfo(
+                memberId, nickname, description);
 
-        log.info("Profile updated by member: {}", memberId);
+        log.info("Profile info updated by member: {}", memberId);
+        return ApiResponse.onSuccess(SuccessStatus.OK, updatedMember);
+    }
+
+    @Operation(summary = "내 프로필 이미지 업데이트", description = "현재 로그인한 사용자의 프로필 이미지를 업로드하고 업데이트합니다.")
+    @SecurityRequirement(name = "JWT")
+    @PutMapping(value = "/me/profile/image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ApiResponse<MemberResponse> updateMyProfileImage(
+            @Parameter(description = "프로필 이미지 파일", required = true)
+            @RequestPart("image") MultipartFile image,
+            @AuthenticationPrincipal UserDetails userDetails) {
+
+        String memberId = userDetails.getUsername(); // JWT에서 member ID 추출
+
+        MemberResponse updatedMember = memberProfileService.updateMemberProfileImage(memberId, image);
+
+        log.info("Profile image updated by member: {}", memberId);
         return ApiResponse.onSuccess(SuccessStatus.OK, updatedMember);
     }
 

--- a/src/main/java/coffeandcommit/crema/domain/member/dto/response/MemberPublicResponse.java
+++ b/src/main/java/coffeandcommit/crema/domain/member/dto/response/MemberPublicResponse.java
@@ -1,0 +1,23 @@
+package coffeandcommit.crema.domain.member.dto.response;
+
+import coffeandcommit.crema.domain.member.enums.MemberRole;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 타인 조회용 회원 정보 응답 DTO
+ * 개인정보 (phoneNumber, point, provider, createdAt) 제외
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder(toBuilder = true)
+public class MemberPublicResponse {
+    private String id;
+    private String nickname;
+    private MemberRole role;
+    private String profileImageUrl;
+    private String description;
+}

--- a/src/main/java/coffeandcommit/crema/domain/member/entity/Member.java
+++ b/src/main/java/coffeandcommit/crema/domain/member/entity/Member.java
@@ -1,14 +1,11 @@
 package coffeandcommit.crema.domain.member.entity;
 
 import coffeandcommit.crema.domain.member.enums.MemberRole;
-import coffeandcommit.crema.global.common.entitiy.BaseEntity;
+import coffeandcommit.crema.global.common.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.SQLRestriction;
-import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-
-import java.time.LocalDateTime;
 
 @Entity
 @Getter
@@ -18,8 +15,13 @@ import java.time.LocalDateTime;
 @SQLRestriction("is_deleted = false") // 회원탈퇴 하지 않은 member만 조회가능하게 설정
 @EntityListeners(AuditingEntityListener.class)
 @Table(name = "member", indexes = {
-        @Index(name = "idx_member_nickname", columnList = "nicknsame")
-})
+        @Index(name = "idx_member_nickname", columnList = "nickname"),
+        @Index(name = "idx_member_provider_provider_id", columnList = "provider, provider_id")
+        },
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_member_provider", columnNames = {"provider", "provider_id"}), // OAuth 회원가입시 중복 방지
+                @UniqueConstraint(name = "uk_member_nickname_is_deleted", columnNames = {"nickname", "is_deleted"}) // 소프트 삭제된 계정의 닉네임을 재사용 가능하게 하되, 활성 계정 간 닉네임 충돌은 금지
+        })
 public class Member extends BaseEntity {
 
     @Id
@@ -36,7 +38,8 @@ public class Member extends BaseEntity {
     private String phoneNumber;
 
     @Column(nullable = false)
-    private Integer point;
+    @Builder.Default
+    private Integer point = 0;
 
     @Column(nullable = true, length = 500)
     private String profileImageUrl;

--- a/src/main/java/coffeandcommit/crema/domain/member/entity/Member.java
+++ b/src/main/java/coffeandcommit/crema/domain/member/entity/Member.java
@@ -65,9 +65,8 @@ public class Member extends BaseEntity {
         if (description != null) {
             this.description = description;
         }
-        if (profileImageUrl != null) {
-            this.profileImageUrl = profileImageUrl;
-        }
+        // profileImageUrl이 null이어도 명시적으로 전달된 경우 업데이트 (이미지 삭제 시)
+        this.profileImageUrl = profileImageUrl;
     }
 
     // 포인트 추가

--- a/src/main/java/coffeandcommit/crema/domain/member/mapper/MemberMapper.java
+++ b/src/main/java/coffeandcommit/crema/domain/member/mapper/MemberMapper.java
@@ -1,14 +1,16 @@
 package coffeandcommit.crema.domain.member.mapper;
 
 import coffeandcommit.crema.domain.member.dto.response.MemberResponse;
+import coffeandcommit.crema.domain.member.dto.response.MemberPublicResponse;
 import coffeandcommit.crema.domain.member.entity.Member;
 import org.mapstruct.Mapper;
-import org.mapstruct.factory.Mappers;
 
-@Mapper
+@Mapper(componentModel = "spring")
 public interface MemberMapper {
 
-    MemberMapper INSTANCE = Mappers.getMapper(MemberMapper.class);
-
+    // 본인 조회용 (모든 필드 포함)
     MemberResponse memberToMemberResponse(Member member);
+
+    // 타인 조회용 (공개 정보만)
+    MemberPublicResponse memberToMemberPublicResponse(Member member);
 }

--- a/src/main/java/coffeandcommit/crema/domain/member/repository/MemberRepository.java
+++ b/src/main/java/coffeandcommit/crema/domain/member/repository/MemberRepository.java
@@ -2,14 +2,22 @@ package coffeandcommit.crema.domain.member.repository;
 
 import coffeandcommit.crema.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, String> {
 
-    Optional<Member> findByNickname(String nickname);
+    @Query("SELECT m FROM Member m WHERE m.id = :id AND m.isDeleted = false")
+    Optional<Member> findByIdAndIsDeletedFalse(@Param("id") String id);
 
-    Optional<Member> findByProviderAndProviderId(String provider, String providerId);
+    @Query("SELECT m FROM Member m WHERE m.nickname = :nickname AND m.isDeleted = false")
+    Optional<Member> findByNicknameAndIsDeletedFalse(@Param("nickname") String nickname);
 
-    boolean existsByNickname(String nickname);
+    @Query("SELECT m FROM Member m WHERE m.provider = :provider AND m.providerId = :providerId AND m.isDeleted = false")
+    Optional<Member> findByProviderAndProviderIdAndIsDeletedFalse(@Param("provider") String provider, @Param("providerId") String providerId);
+
+    @Query("SELECT CASE WHEN COUNT(m) > 0 THEN true ELSE false END FROM Member m WHERE m.nickname = :nickname AND m.isDeleted = false")
+    boolean existsByNicknameAndIsDeletedFalse(@Param("nickname") String nickname);
 }

--- a/src/main/java/coffeandcommit/crema/domain/member/service/MemberProfileService.java
+++ b/src/main/java/coffeandcommit/crema/domain/member/service/MemberProfileService.java
@@ -1,0 +1,225 @@
+package coffeandcommit.crema.domain.member.service;
+
+import coffeandcommit.crema.domain.member.dto.response.MemberResponse;
+import coffeandcommit.crema.domain.member.entity.Member;
+import coffeandcommit.crema.domain.member.mapper.MemberMapper;
+import coffeandcommit.crema.domain.member.repository.MemberRepository;
+import coffeandcommit.crema.global.AWS.service.ImageService;
+import coffeandcommit.crema.global.common.exception.BaseException;
+import coffeandcommit.crema.global.common.exception.code.ErrorStatus;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MemberProfileService {
+
+    private final MemberRepository memberRepository;
+    private final MemberMapper memberMapper;
+    private final ImageService imageService;
+
+    // 프로필 이미지 전용 설정
+    private static final List<String> ALLOWED_PROFILE_IMAGE_TYPES = Arrays.asList(
+            "image/jpeg", "image/jpg", "image/png"
+    );
+    private static final long MAX_PROFILE_IMAGE_SIZE = 2 * 1024 * 1024; // 2MB
+    private static final int MIN_PROFILE_IMAGE_DIMENSION = 100; // 최소 100x100
+    private static final int MAX_PROFILE_IMAGE_DIMENSION = 1024; // 최대 1024x1024
+
+    /**
+     * 회원 프로필 이미지 등록/업데이트
+     */
+    @Transactional
+    public MemberResponse updateMemberProfileImage(String id, MultipartFile imageFile) {
+        Member member = memberRepository.findByIdAndIsDeletedFalse(id)
+                .orElseThrow(() -> new BaseException(ErrorStatus.MEMBER_NOT_FOUND));
+
+        try {
+            // 프로필 이미지 전용 검증
+            validateProfileImageFile(imageFile);
+
+            // 기존 프로필 이미지가 있다면 삭제
+            if (member.getProfileImageUrl() != null) {
+                // URL에서 S3 키 추출하여 삭제
+                String oldImageKey = extractS3KeyFromUrl(member.getProfileImageUrl());
+                if (oldImageKey != null) {
+                    imageService.deleteImage(oldImageKey);
+                    log.info("Old profile image deleted for member: {}, imageKey: {}", id, oldImageKey);
+                }
+            }
+
+            // 새 프로필 이미지 업로드
+            var uploadResponse = imageService.uploadProfileImage(imageFile, id);
+
+            // DB 업데이트
+            member.updateProfile(null, null, uploadResponse.getImageUrl());
+            Member savedMember = memberRepository.save(member);
+
+            log.info("Member profile image updated: {}, new imageKey: {}", id, uploadResponse.getImageKey());
+            return memberMapper.memberToMemberResponse(savedMember);
+
+        } catch (BaseException e) {
+            throw e; // BaseException은 그대로 전파
+        } catch (Exception e) {
+            log.error("Failed to update profile image for member: {} - {}", id, e.getMessage());
+            throw new BaseException(ErrorStatus.FILE_UPLOAD_FAILED);
+        }
+    }
+
+    /**
+     * 회원의 프로필 이미지 삭제 (회원 탈퇴 시 사용)
+     */
+    @Transactional
+    public void deleteProfileImage(String memberId) {
+        Member member = memberRepository.findByIdAndIsDeletedFalse(memberId)
+                .orElseThrow(() -> new BaseException(ErrorStatus.MEMBER_NOT_FOUND));
+
+        if (member.getProfileImageUrl() != null) {
+            String imageKey = extractS3KeyFromUrl(member.getProfileImageUrl());
+            if (imageKey != null) {
+                try {
+                    imageService.deleteImage(imageKey);
+                    log.info("Profile image deleted for member: {}, imageKey: {}", memberId, imageKey);
+                } catch (Exception e) {
+                    log.warn("Failed to delete profile image for member: {} - {}", memberId, e.getMessage());
+                    // 이미지 삭제 실패해도 예외를 던지지 않음 (회원 탈퇴는 계속 진행)
+                }
+            }
+
+            // DB에서 프로필 이미지 URL 제거
+            member.updateProfile(null, null, null);
+            memberRepository.save(member);
+        }
+    }
+
+    /**
+     * 프로필 이미지 전용 검증
+     */
+    private void validateProfileImageFile(MultipartFile file) {
+        if (file == null || file.isEmpty()) {
+            throw new BaseException(ErrorStatus.INVALID_FILE_FORMAT);
+        }
+
+        // 1. 파일 크기 검증 (2MB 제한)
+        if (file.getSize() > MAX_PROFILE_IMAGE_SIZE) {
+            throw new BaseException(ErrorStatus.FILE_SIZE_EXCEEDED);
+        }
+
+        // 2. MIME 타입 검증
+        String contentType = file.getContentType();
+        if (contentType == null || !ALLOWED_PROFILE_IMAGE_TYPES.contains(contentType.toLowerCase())) {
+            throw new BaseException(ErrorStatus.INVALID_FILE_FORMAT);
+        }
+
+        // 3. 파일명 및 확장자 검증
+        String originalFilename = file.getOriginalFilename();
+        if (originalFilename == null || originalFilename.trim().isEmpty()) {
+            throw new BaseException(ErrorStatus.INVALID_FILE_FORMAT);
+        }
+
+        String extension = getFileExtension(originalFilename);
+        if (!isValidProfileImageExtension(extension)) {
+            throw new BaseException(ErrorStatus.INVALID_FILE_FORMAT);
+        }
+
+        // 4. 파일 시그니처 검증 (Magic Number)
+        try {
+            byte[] fileBytes = file.getBytes();
+            if (!isValidImageFileSignature(fileBytes)) {
+                throw new BaseException(ErrorStatus.INVALID_FILE_FORMAT);
+            }
+        } catch (Exception e) {
+            log.error("Failed to read file bytes for signature validation: {}", e.getMessage());
+            throw new BaseException(ErrorStatus.INVALID_FILE_FORMAT);
+        }
+
+        log.debug("Profile image validation passed for file: {}, size: {}, type: {}",
+                originalFilename, file.getSize(), contentType);
+    }
+
+    /**
+     * 파일 시그니처 검증 (Magic Number)
+     */
+    private boolean isValidImageFileSignature(byte[] fileBytes) {
+        if (fileBytes == null || fileBytes.length < 4) {
+            return false;
+        }
+
+        // JPEG 시그니처: FF D8 FF
+        if (fileBytes.length >= 3 &&
+                fileBytes[0] == (byte) 0xFF &&
+                fileBytes[1] == (byte) 0xD8 &&
+                fileBytes[2] == (byte) 0xFF) {
+            return true;
+        }
+
+        // PNG 시그니처: 89 50 4E 47 0D 0A 1A 0A
+        if (fileBytes.length >= 8 &&
+                fileBytes[0] == (byte) 0x89 &&
+                fileBytes[1] == (byte) 0x50 &&
+                fileBytes[2] == (byte) 0x4E &&
+                fileBytes[3] == (byte) 0x47 &&
+                fileBytes[4] == (byte) 0x0D &&
+                fileBytes[5] == (byte) 0x0A &&
+                fileBytes[6] == (byte) 0x1A &&
+                fileBytes[7] == (byte) 0x0A) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * 프로필 이미지 허용 확장자 검증
+     */
+    private boolean isValidProfileImageExtension(String extension) {
+        if (extension == null) {
+            return false;
+        }
+
+        List<String> allowedExtensions = Arrays.asList("jpg", "jpeg", "png");
+        return allowedExtensions.contains(extension.toLowerCase());
+    }
+
+    /**
+     * 파일 확장자 추출
+     */
+    private String getFileExtension(String filename) {
+        if (filename == null || !filename.contains(".")) {
+            return null;
+        }
+        return filename.substring(filename.lastIndexOf(".") + 1);
+    }
+
+    /**
+     * 이미지 URL에서 S3 키 추출
+     */
+    private String extractS3KeyFromUrl(String imageUrl) {
+        if (imageUrl == null || imageUrl.trim().isEmpty()) {
+            return null;
+        }
+
+        try {
+            // URL 형태: https://bucket.s3.region.amazonaws.com/folder/filename
+            // 또는: https://bucket.s3.amazonaws.com/folder/filename
+            if (imageUrl.contains(".amazonaws.com/")) {
+                int keyStartIndex = imageUrl.indexOf(".amazonaws.com/") + 15;
+                if (keyStartIndex < imageUrl.length()) {
+                    return imageUrl.substring(keyStartIndex);
+                }
+            }
+            return null;
+        } catch (Exception e) {
+            log.warn("Failed to extract S3 key from URL: {}", imageUrl);
+            return null;
+        }
+    }
+}

--- a/src/main/java/coffeandcommit/crema/domain/member/service/MemberService.java
+++ b/src/main/java/coffeandcommit/crema/domain/member/service/MemberService.java
@@ -1,9 +1,11 @@
 package coffeandcommit.crema.domain.member.service;
 
+import coffeandcommit.crema.domain.member.dto.response.MemberPublicResponse;
 import coffeandcommit.crema.domain.member.dto.response.MemberResponse;
 import coffeandcommit.crema.domain.member.entity.Member;
 import coffeandcommit.crema.domain.member.mapper.MemberMapper;
 import coffeandcommit.crema.domain.member.repository.MemberRepository;
+import coffeandcommit.crema.global.auth.service.CustomUserDetails;
 import coffeandcommit.crema.global.common.exception.BaseException;
 import coffeandcommit.crema.global.common.exception.code.ErrorStatus;
 import lombok.RequiredArgsConstructor;
@@ -18,22 +20,31 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberService {
 
     private final MemberRepository memberRepository;
+    private final MemberMapper memberMapper;
 
     /**
-     * ID로 회원 조회
+     * ID로 회원 조회 - 본인용 (모든 정보 포함)
      */
-    public MemberResponse getMemberById(String id) {
-        Member member = findMemberById(id);
-        return MemberMapper.INSTANCE.memberToMemberResponse(member);
+    public MemberResponse getMyInfo(String id) {
+        Member member = findActiveMemberById(id);
+        return memberMapper.memberToMemberResponse(member);
     }
 
     /**
-     * 닉네임으로 회원 조회
+     * ID로 회원 조회 - 타인용 (공개 정보만)
      */
-    public MemberResponse getMemberByNickname(String nickname) {
-        Member member = memberRepository.findByNickname(nickname)
+    public MemberPublicResponse getMemberById(String id) {
+        Member member = findActiveMemberById(id);
+        return memberMapper.memberToMemberPublicResponse(member);
+    }
+
+    /**
+     * 닉네임으로 회원 조회 - 타인용 (공개 정보만)
+     */
+    public MemberPublicResponse getMemberByNickname(String nickname) {
+        Member member = memberRepository.findByNicknameAndIsDeletedFalse(nickname)
                 .orElseThrow(() -> new BaseException(ErrorStatus.MEMBER_NOT_FOUND));
-        return MemberMapper.INSTANCE.memberToMemberResponse(member);
+        return memberMapper.memberToMemberPublicResponse(member);
     }
 
     /**
@@ -41,12 +52,12 @@ public class MemberService {
      */
     @Transactional
     public MemberResponse updateMemberProfile(String id, String nickname, String description, String profileImageUrl) {
-        Member member = findMemberById(id);
+        Member member = findActiveMemberById(id);
 
-        // 닉네임 중복 체크 (본인 제외)
+        // 닉네임 중복 체크 (본인 제외, 활성 회원만)
         if (nickname != null && !nickname.trim().isEmpty() &&
                 !nickname.equals(member.getNickname()) &&
-                memberRepository.existsByNickname(nickname)) {
+                memberRepository.existsByNicknameAndIsDeletedFalse(nickname)) {
             throw new BaseException(ErrorStatus.NICKNAME_DUPLICATED);
         }
 
@@ -59,35 +70,35 @@ public class MemberService {
         Member savedMember = memberRepository.save(member);
 
         log.info("Member profile updated: {}", id);
-        return MemberMapper.INSTANCE.memberToMemberResponse(savedMember);
+        return memberMapper.memberToMemberResponse(savedMember);
     }
 
     /**
-     * 회원 삭제
+     * 회원 삭제 (소프트 삭제)
      */
     @Transactional
     public void deleteMember(String id) {
-        Member member = findMemberById(id);
+        Member member = findActiveMemberById(id);
         member.softDelete(); // isDeleted = true로 변경
         memberRepository.save(member);
         log.info("Member soft deleted: {}", id);
     }
 
     /**
-     * 닉네임 사용 가능 여부 확인
+     * 닉네임 사용 가능 여부 확인 (활성 회원만 체크)
      */
     public boolean isNicknameAvailable(String nickname) {
         if (nickname == null || nickname.trim().isEmpty()) {
             return false;
         }
-        return !memberRepository.existsByNickname(nickname) && isValidNickname(nickname);
+        return !memberRepository.existsByNicknameAndIsDeletedFalse(nickname) && isValidNickname(nickname);
     }
 
     /**
      * 회원 포인트 조회
      */
     public int getMemberPoints(String id) {
-        Member member = findMemberById(id);
+        Member member = findActiveMemberById(id);
         return member.getPoint();
     }
 
@@ -96,7 +107,7 @@ public class MemberService {
      */
     @Transactional
     public void addPoints(String id, int point) {
-        Member member = findMemberById(id);
+        Member member = findActiveMemberById(id);
         member.addPoint(point);
         memberRepository.save(member);
         log.info("Points added to member {}: +{}", id, point);
@@ -107,16 +118,31 @@ public class MemberService {
      */
     @Transactional
     public void decreasePoints(String id, int point) {
-        Member member = findMemberById(id);
+        Member member = findActiveMemberById(id);
         member.decreasePoint(point);
         memberRepository.save(member);
         log.info("Points decreased from member {}: -{}", id, point);
     }
 
+    // === UserDetails 관련 메서드 추가 ===
+
+    /**
+     * JWT 인증을 위한 UserDetails 생성
+     */
+    public CustomUserDetails createUserDetails(String memberId) {
+        Member member = findActiveMemberById(memberId);
+        // 탈퇴하지 않은 회원만 enabled=true
+        boolean enabled = !Boolean.TRUE.equals(member.getIsDeleted());
+        return new CustomUserDetails(memberId, enabled);
+    }
+
     // === Private Helper Methods ===
 
-    private Member findMemberById(String id) {
-        return memberRepository.findById(id)
+    /**
+     * 활성 회원만 조회하는 안전한 메서드
+     */
+    private Member findActiveMemberById(String id) {
+        return memberRepository.findByIdAndIsDeletedFalse(id)
                 .orElseThrow(() -> new BaseException(ErrorStatus.MEMBER_NOT_FOUND));
     }
 

--- a/src/main/java/coffeandcommit/crema/domain/member/service/MemberService.java
+++ b/src/main/java/coffeandcommit/crema/domain/member/service/MemberService.java
@@ -133,7 +133,7 @@ public class MemberService {
         Member member = findActiveMemberById(memberId);
         // 탈퇴하지 않은 회원만 enabled=true
         boolean enabled = !Boolean.TRUE.equals(member.getIsDeleted());
-        return new CustomUserDetails(memberId, enabled);
+        return new CustomUserDetails(memberId, enabled, member.getRole());
     }
 
     // === Private Helper Methods ===

--- a/src/main/java/coffeandcommit/crema/global/auth/config/SecurityConfig.java
+++ b/src/main/java/coffeandcommit/crema/global/auth/config/SecurityConfig.java
@@ -13,7 +13,6 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -36,18 +35,10 @@ public class SecurityConfig {
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
-                .csrf(csrf -> csrf
-                        .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
-                        .ignoringRequestMatchers(
-                                "/api/auth/refresh",
-                                "/oauth2/**",
-                                "/login/oauth2/**",
-                                "/swagger-ui/**",
-                                "/v3/api-docs/**",
-                                "/actuator/**"
-                        )
-                )
+                .csrf(csrf -> csrf.disable()) // ← CSRF 완전 비활성화
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .requestCache(cache -> cache.disable()) // ← 요청 캐시 비활성화 (JSESSIONID 제거)
+                .securityContext(context -> context.requireExplicitSave(false)) // ← 보안 컨텍스트 자동 저장 비활성화
                 .exceptionHandling(exception -> exception.authenticationEntryPoint(jwtAuthenticationEntryPoint))
                 .authorizeHttpRequests(auth -> auth
                         // Public endpoints (인증 불필요)
@@ -99,7 +90,7 @@ public class SecurityConfig {
         configuration.setAllowedOriginPatterns(List.of(
                 "http://localhost:3000",
                 "http://localhost:3001",
-                "https://yourdomain.com"
+                "https://yourdomain.com" // ← 운영환경에서 실제 도메인으로 변경 필요
         ));
 
         configuration.setAllowedMethods(Arrays.asList(

--- a/src/main/java/coffeandcommit/crema/global/auth/config/SecurityConfig.java
+++ b/src/main/java/coffeandcommit/crema/global/auth/config/SecurityConfig.java
@@ -13,6 +13,7 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -35,7 +36,17 @@ public class SecurityConfig {
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
-                .csrf(csrf -> csrf.disable())
+                .csrf(csrf -> csrf
+                        .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
+                        .ignoringRequestMatchers(
+                                "/api/auth/refresh",
+                                "/oauth2/**",
+                                "/login/oauth2/**",
+                                "/swagger-ui/**",
+                                "/v3/api-docs/**",
+                                "/actuator/**"
+                        )
+                )
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .exceptionHandling(exception -> exception.authenticationEntryPoint(jwtAuthenticationEntryPoint))
                 .authorizeHttpRequests(auth -> auth

--- a/src/main/java/coffeandcommit/crema/global/auth/controller/AuthController.java
+++ b/src/main/java/coffeandcommit/crema/global/auth/controller/AuthController.java
@@ -1,8 +1,8 @@
 package coffeandcommit.crema.global.auth.controller;
 
-import coffeandcommit.crema.domain.member.dto.response.MemberResponse;
-import coffeandcommit.crema.domain.member.service.MemberService;
 import coffeandcommit.crema.global.auth.service.AuthService;
+import coffeandcommit.crema.global.common.exception.BaseException;
+import coffeandcommit.crema.global.common.exception.code.ErrorStatus;
 import coffeandcommit.crema.global.common.exception.response.ApiResponse;
 import coffeandcommit.crema.global.common.exception.code.SuccessStatus;
 import io.swagger.v3.oas.annotations.Operation;
@@ -24,22 +24,18 @@ import org.springframework.web.bind.annotation.*;
 public class AuthController {
 
     private final AuthService authService;
-    private final MemberService memberService;
-
-    @Operation(summary = "현재 로그인 사용자 정보 조회", description = "쿠키의 JWT 토큰을 통해 현재 로그인된 사용자 정보를 조회합니다.")
-    @SecurityRequirement(name = "JWT")
-    @GetMapping("/me")
-    public ApiResponse<MemberResponse> getCurrentUser(@AuthenticationPrincipal UserDetails userDetails) {
-        String memberId = userDetails.getUsername(); // JWT에서 member ID 추출
-        MemberResponse member = memberService.getMemberById(memberId);
-        return ApiResponse.onSuccess(SuccessStatus.OK, member);
-    }
 
     @Operation(summary = "로그아웃", description = "쿠키에서 JWT 토큰을 삭제하고 토큰을 블랙리스트에 추가하여 로그아웃 처리합니다.")
     @SecurityRequirement(name = "JWT")
     @PostMapping("/logout")
     public ApiResponse<Void> logout(HttpServletRequest request, HttpServletResponse response,
                                     @AuthenticationPrincipal UserDetails userDetails) {
+
+        // 인증되지 않은 사용자 체크
+        if (userDetails == null) {
+            throw new BaseException(ErrorStatus.UNAUTHORIZED);
+        }
+
         String memberId = userDetails.getUsername(); // JWT에서 member ID 추출
         authService.logout(request, response, memberId);
         return ApiResponse.onSuccess(SuccessStatus.OK, null);

--- a/src/main/java/coffeandcommit/crema/global/auth/handler/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/coffeandcommit/crema/global/auth/handler/OAuth2AuthenticationSuccessHandler.java
@@ -27,7 +27,15 @@ public class OAuth2AuthenticationSuccessHandler implements AuthenticationSuccess
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
                                         Authentication authentication) throws IOException {
 
-        CustomOAuth2User oAuth2User = (CustomOAuth2User) authentication.getPrincipal();
+        // Principal 타입 안전성 검사
+        Object principal = authentication.getPrincipal();
+        if (!(principal instanceof CustomOAuth2User)) {
+            log.error("Unexpected principal type: {}", principal != null ? principal.getClass().getSimpleName() : "null");
+            response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+            return;
+        }
+
+        CustomOAuth2User oAuth2User = (CustomOAuth2User) principal;
         String memberId = oAuth2User.getMember().getId();
 
         // 쿠키에 토큰 설정

--- a/src/main/java/coffeandcommit/crema/global/auth/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/coffeandcommit/crema/global/auth/jwt/JwtAuthenticationEntryPoint.java
@@ -4,14 +4,17 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 @Slf4j
 @Component
@@ -22,11 +25,34 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response,
                          AuthenticationException authException) throws IOException {
+
         log.debug("인증되지 않은 요청입니다: {}", authException.getMessage());
 
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
 
+        // JWT 에러 타입 결정
+        String error = "invalid_token";
+        String errorDescription = Optional.ofNullable(authException.getMessage())
+                .orElse("Unauthorized");
+
+        // 에러 메시지 기반으로 구체적인 에러 코드 결정
+        if (errorDescription.contains("expired") || errorDescription.contains("만료")) {
+            error = "expired_token";
+        } else if (errorDescription.contains("invalid") || errorDescription.contains("유효하지")) {
+            error = "invalid_token";
+        }
+
+        // RFC 6750 표준에 따른 WWW-Authenticate 헤더 설정
+        String wwwAuthenticateValue = String.format(
+                "Bearer error=\"%s\", error_description=\"%s\"",
+                error,
+                errorDescription.replace("\"", "\\\"") // 따옴표 이스케이프
+        );
+        response.setHeader(HttpHeaders.WWW_AUTHENTICATE, wwwAuthenticateValue);
+
+        // JSON 응답 바디
         Map<String, Object> responseMap = new HashMap<>();
         responseMap.put("error", "Unauthorized");
         responseMap.put("message", "인증이 필요합니다.");

--- a/src/main/java/coffeandcommit/crema/global/auth/provider/GoogleOAuth2UserInfo.java
+++ b/src/main/java/coffeandcommit/crema/global/auth/provider/GoogleOAuth2UserInfo.java
@@ -19,14 +19,4 @@ public class GoogleOAuth2UserInfo implements OAuth2UserInfo {
     public String getName() {
         return (String) attributes.get("name");
     }
-
-    @Override
-    public String getEmail() {
-        return (String) attributes.get("email");
-    }
-
-    @Override
-    public String getImageUrl() {
-        return (String) attributes.get("picture");
-    }
 }

--- a/src/main/java/coffeandcommit/crema/global/auth/provider/KakaoOAuth2UserInfo.java
+++ b/src/main/java/coffeandcommit/crema/global/auth/provider/KakaoOAuth2UserInfo.java
@@ -38,49 +38,4 @@ public class KakaoOAuth2UserInfo implements OAuth2UserInfo {
 
         return null;
     }
-
-    @Override
-    public String getEmail() {
-        Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
-        if (kakaoAccount == null) {
-            return null;
-        }
-
-        // 이메일 동의 및 유효성 체크
-        Boolean emailNeedsAgreement = (Boolean) kakaoAccount.get("email_needs_agreement");
-        Boolean isEmailValid = (Boolean) kakaoAccount.get("is_email_valid");
-        Boolean isEmailVerified = (Boolean) kakaoAccount.get("is_email_verified");
-
-        // 이메일 동의가 필요하거나, 유효하지 않거나, 인증되지 않은 경우 null 반환
-        if (Boolean.TRUE.equals(emailNeedsAgreement) ||
-                Boolean.FALSE.equals(isEmailValid) ||
-                Boolean.FALSE.equals(isEmailVerified)) {
-            return null;
-        }
-
-        return (String) kakaoAccount.get("email");
-    }
-
-    @Override
-    public String getImageUrl() {
-        // v2 권장 경로 우선 시도: kakao_account.profile.profile_image_url
-        Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
-        if (kakaoAccount != null) {
-            Map<String, Object> profile = (Map<String, Object>) kakaoAccount.get("profile");
-            if (profile != null) {
-                String profileImageUrl = (String) profile.get("profile_image_url");
-                if (profileImageUrl != null) {
-                    return profileImageUrl;
-                }
-            }
-        }
-
-        // 백워드 호환성을 위한 v1 경로: properties.profile_image
-        Map<String, Object> properties = (Map<String, Object>) attributes.get("properties");
-        if (properties != null) {
-            return (String) properties.get("profile_image");
-        }
-
-        return null;
-    }
 }

--- a/src/main/java/coffeandcommit/crema/global/auth/provider/OAuth2UserInfo.java
+++ b/src/main/java/coffeandcommit/crema/global/auth/provider/OAuth2UserInfo.java
@@ -3,8 +3,6 @@ package coffeandcommit.crema.global.auth.provider;
 import jakarta.validation.constraints.NotNull;
 
 public interface OAuth2UserInfo {
-    @NotNull String getId();
-    String getName();
-    String getEmail();
-    String getImageUrl();
+    @NotNull String getId();    // OAuth 제공자의 고유 ID (필수)
+    String getName();           // 사용자 이름 (닉네임 생성용)
 }

--- a/src/main/java/coffeandcommit/crema/global/auth/provider/OAuth2UserInfo.java
+++ b/src/main/java/coffeandcommit/crema/global/auth/provider/OAuth2UserInfo.java
@@ -1,7 +1,9 @@
 package coffeandcommit.crema.global.auth.provider;
 
+import jakarta.validation.constraints.NotNull;
+
 public interface OAuth2UserInfo {
-    String getId();
+    @NotNull String getId();
     String getName();
     String getEmail();
     String getImageUrl();

--- a/src/main/java/coffeandcommit/crema/global/auth/service/CustomOAuth2User.java
+++ b/src/main/java/coffeandcommit/crema/global/auth/service/CustomOAuth2User.java
@@ -4,6 +4,7 @@ import coffeandcommit.crema.domain.member.entity.Member;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 
 import java.util.Collection;
@@ -24,7 +25,9 @@ public class CustomOAuth2User implements OAuth2User {
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return Collections.emptyList(); // 추후에 admin role 같은거 쓸거면 여기에서 security role 설정
+        // MemberRole을 Spring Security GrantedAuthority로 변환
+        String roleName = "ROLE_" + member.getRole().name();
+        return Collections.singletonList(new SimpleGrantedAuthority(roleName));
     }
 
     @Override

--- a/src/main/java/coffeandcommit/crema/global/auth/service/CustomOAuth2UserService.java
+++ b/src/main/java/coffeandcommit/crema/global/auth/service/CustomOAuth2UserService.java
@@ -68,9 +68,6 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
             throw new OAuth2AuthenticationException("탈퇴한 계정입니다.");
         }
 
-        // 사용자 정보 업데이트 (프로필 이미지, 이름 등이 변경될 수 있음)
-        updateMemberInfo(member, userInfo);
-
         return new CustomOAuth2User(member, oAuth2User.getAttributes());
     }
 
@@ -100,7 +97,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
                 .nickname(uniqueNickname)
                 .role(MemberRole.ROOKIE)
                 .point(0) // 초기 포인트
-                .profileImageUrl(userInfo.getImageUrl())
+                .profileImageUrl(null) // 프로필 이미지는 항상 null로 시작
                 .provider(provider)
                 .providerId(userInfo.getId())
                 .build();
@@ -109,23 +106,6 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
                 provider, userInfo.getId(), uniqueNickname);
 
         return memberRepository.save(member);
-    }
-
-    private void updateMemberInfo(Member member, OAuth2UserInfo userInfo) {
-        boolean updated = false;
-
-        // 프로필 이미지 업데이트 (기존에 없거나 OAuth 제공자의 이미지가 더 최신인 경우)
-        if (StringUtils.hasText(userInfo.getImageUrl()) &&
-                !StringUtils.hasText(member.getProfileImageUrl())) {
-
-            member.updateProfile(null, null, userInfo.getImageUrl());
-            updated = true;
-        }
-
-        if (updated) {
-            memberRepository.save(member);
-            log.info("Updated member info for: {}", member.getId());
-        }
     }
 
     private String generateUniqueNickname(String baseName) {

--- a/src/main/java/coffeandcommit/crema/global/auth/service/CustomUserDetails.java
+++ b/src/main/java/coffeandcommit/crema/global/auth/service/CustomUserDetails.java
@@ -1,7 +1,9 @@
 package coffeandcommit.crema.global.auth.service;
 
+import coffeandcommit.crema.domain.member.enums.MemberRole;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
 import java.util.Collection;
@@ -12,10 +14,13 @@ public class CustomUserDetails implements UserDetails {
 
     private final String memberId;
     private final boolean enabled; // 사용자 활성/비활성 상태 필드 추가
+    private final MemberRole memberRole; // 회원 역할 추가
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return Collections.emptyList();
+        // MemberRole을 Spring Security GrantedAuthority로 변환
+        String roleName = "ROLE_" + memberRole.name();
+        return Collections.singletonList(new SimpleGrantedAuthority(roleName));
     }
 
     @Override

--- a/src/main/java/coffeandcommit/crema/global/auth/service/CustomUserDetails.java
+++ b/src/main/java/coffeandcommit/crema/global/auth/service/CustomUserDetails.java
@@ -11,6 +11,7 @@ import java.util.Collections;
 public class CustomUserDetails implements UserDetails {
 
     private final String memberId;
+    private final boolean enabled; // 사용자 활성/비활성 상태 필드 추가
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
@@ -44,6 +45,6 @@ public class CustomUserDetails implements UserDetails {
 
     @Override
     public boolean isEnabled() {
-        return true;
+        return enabled; // 실제 회원 상태 반영
     }
 }

--- a/src/main/java/coffeandcommit/crema/global/common/entity/BaseEntity.java
+++ b/src/main/java/coffeandcommit/crema/global/common/entity/BaseEntity.java
@@ -1,4 +1,4 @@
-package coffeandcommit.crema.global.common.entitiy;
+package coffeandcommit.crema.global.common.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;

--- a/src/main/java/coffeandcommit/crema/global/common/exception/code/ErrorStatus.java
+++ b/src/main/java/coffeandcommit/crema/global/common/exception/code/ErrorStatus.java
@@ -15,6 +15,7 @@ public enum ErrorStatus implements BaseCode {
     VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "유효성 검사 실패"),
     METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "지원하지 않은 HTTP Method 입니다."),
     FORBIDDEN(HttpStatus.FORBIDDEN, "권한이 없습니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다."),
 
     // Member Domain
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 사용자를 찾을 수 없습니다."),

--- a/src/main/java/coffeandcommit/crema/global/common/exception/code/ErrorStatus.java
+++ b/src/main/java/coffeandcommit/crema/global/common/exception/code/ErrorStatus.java
@@ -32,10 +32,11 @@ public enum ErrorStatus implements BaseCode {
     OAUTH2_AUTHENTICATION_FAILED(HttpStatus.UNAUTHORIZED, "OAuth2 인증에 실패했습니다."),
     UNSUPPORTED_OAUTH2_PROVIDER(HttpStatus.BAD_REQUEST, "지원하지 않는 OAuth2 제공자입니다."),
 
-    // File Upload
+    // File Upload - 프로필 이미지 전용 에러 추가
     FILE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "파일 업로드에 실패했습니다."),
-    INVALID_FILE_FORMAT(HttpStatus.BAD_REQUEST, "지원하지 않는 파일 형식입니다."),
-    FILE_SIZE_EXCEEDED(HttpStatus.BAD_REQUEST, "파일 크기가 제한을 초과했습니다.");
+    INVALID_FILE_FORMAT(HttpStatus.BAD_REQUEST, "유효하지 않은 이미지 파일입니다. 실제 JPG, JPEG, PNG 파일만 업로드 가능합니다."),
+    FILE_SIZE_EXCEEDED(HttpStatus.BAD_REQUEST, "파일 크기가 제한을 초과했습니다. (최대 2MB)"),
+    PROFILE_IMAGE_DIMENSION_INVALID(HttpStatus.BAD_REQUEST, "이미지 크기가 올바르지 않습니다. (100x100 ~ 1024x1024 권장)");
 
     public static final String PREFIX = "[ERROR]";
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -82,6 +82,7 @@ app:
     authorized-redirect-uri: http://localhost:8080/swagger-ui/index.html # ${FRONTEND_URL:http://localhost:3000}/oauth2/redirect
   cookie:
     domain: ${COOKIE_DOMAIN:} # 운영환경에서 도메인 설정, 개발환경에선 빈 문자열
+    same-site: ${COOKIE_SAMESITE:Lax}  # OAuth2에서는 Lax가 적절, CSRF 공격 방어 가능
 
 cloud:
   aws:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -46,7 +46,6 @@ spring:
             client-secret: ${GOOGLE_CLIENT_SECRET}
             redirect-uri: "{baseUrl}/login/oauth2/code/google"
             scope:
-              - email
               - profile
           kakao:
             client-id: ${KAKAO_CLIENT_ID}


### PR DESCRIPTION
# 🚀 What’s this PR about?
- auth&member 도메인 리팩토링

# 🛠️ What’s been done?
1. member 도메인
- 사진 업데이트 로직 분리 + 사진 업로드 검증 로직 추가
- reponse를 본인 조회용과 타인 조회용으로 분리

2. auth 도메인
- OAuth2에서 사용자를 불러올 때, email과 profileImage를 불러오지 않게 설정
- 삭제된 계정의 acees/refresh 토큰이 즉시 redis blacklist에 들어가게 수정
- 그 외 보안 헛점들 개선

3. 기타
- 오타 수정

# 🧪 Testing Details
- 이전 pr과 똑같이 테스트 하면 됩니다.
- 이전 pr: https://github.com/Coffee-Commit/Crema_Backend/pull/16

# 👀 Checkpoints for Reviewers
- 아직 s3를 활성화하지 않아 사진 업로드 관련된 테스트는 아직 못 해봤습니다. s3 관련 이슈 해결할 때 사진 업로드 테스트도 진행하겠습니다.

# 🎯 Related Issues
closes #23 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 프로필 이미지 업로드/교체/삭제 API 추가(멀티파트).
  - 내 프로필 수정 기능을 정보/이미지로 분리.

- Bug Fixes
  - OAuth2 성공 시 사용자 타입 검증 추가로 예외 방지, 실패 시 에러코드 기반 리다이렉트로 가시성 개선.
  - 삭제된 계정의 로그인/인증 차단, 표준 WWW-Authenticate 헤더로 토큰 오류 전달.

- Chores
  - 공개 멤버 조회는 비공개 항목을 제외한 공개 프로필로 응답.
  - Google 로그인 권한에서 이메일 제거(프로필만 요청).
  - 쿠키 SameSite 설정 지원, JWT에 jti 포함.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->