### PR TITLE
엔티티 추가

### DIFF
--- a/src/main/java/coffeandcommit/crema/domain/guide/entity/ExperienceDetail.java
+++ b/src/main/java/coffeandcommit/crema/domain/guide/entity/ExperienceDetail.java
@@ -22,5 +22,11 @@ public class ExperienceDetail extends BaseEntity{
     private ExperienceGroup groupId; // FK, 가이드 ID
 
     @Column(nullable = false)
-    private String experienceDetail; // 상세 설명
+    private String who;
+
+    @Column(nullable = false)
+    private String solution;
+
+    @Column(nullable = false)
+    private String how;
 }

--- a/src/main/java/coffeandcommit/crema/domain/meeting/entity/MeetingRoom.java
+++ b/src/main/java/coffeandcommit/crema/domain/meeting/entity/MeetingRoom.java
@@ -19,7 +19,7 @@ public class MeetingRoom extends BaseEntity{
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @OneToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "reservation_id", nullable = false)
     private Reservation reservationId; // FK, 예약 ID
 

--- a/src/main/java/coffeandcommit/crema/domain/meeting/entity/MeetingRoom.java
+++ b/src/main/java/coffeandcommit/crema/domain/meeting/entity/MeetingRoom.java
@@ -20,7 +20,7 @@ public class MeetingRoom extends BaseEntity{
     private Long id;
 
     @OneToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "reservation_id", nullable = false)
+    @JoinColumn(name = "reservation_id", nullable = false, unique = true)
     private Reservation reservationId; // FK, 예약 ID
 
     @Column(nullable = false)

--- a/src/main/java/coffeandcommit/crema/domain/reservation/entity/Reservation.java
+++ b/src/main/java/coffeandcommit/crema/domain/reservation/entity/Reservation.java
@@ -31,7 +31,7 @@ public class Reservation extends BaseEntity{
     private Member memberId; // FK, 멤버 ID는 String (UUID)
 
     @OneToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "survey_id", nullable = false)
+    @JoinColumn(name = "survey_id", nullable = false, unique = true)
     private Survey surveyId; // FK, 설문 ID
 
     private LocalDateTime matchingTime;

--- a/src/main/java/coffeandcommit/crema/domain/reservation/entity/Reservation.java
+++ b/src/main/java/coffeandcommit/crema/domain/reservation/entity/Reservation.java
@@ -30,14 +30,14 @@ public class Reservation extends BaseEntity{
     @JoinColumn(name = "member_id", nullable = false)
     private Member memberId; // FK, 멤버 ID는 String (UUID)
 
-    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @OneToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "survey_id", nullable = false)
     private Survey surveyId; // FK, 설문 ID
 
     private LocalDateTime matchingTime;
 
     @Enumerated(EnumType.STRING)
-    private Status status; // 예약 상태 (예: PENDING, CONFIRMED, CANCELLED 등)
+    private Status status; // 예약 상태 (예: PENDING, CONFIRMED, COMPLETED)
 
     private String reason;
 

--- a/src/main/java/coffeandcommit/crema/domain/reservation/enums/Status.java
+++ b/src/main/java/coffeandcommit/crema/domain/reservation/enums/Status.java
@@ -11,6 +11,7 @@ public enum Status {
 
     PENDING,
     CONFIRMED,
+    CANCELLED,
     COMPLETED
 
 }

--- a/src/main/java/coffeandcommit/crema/domain/reservation/enums/Status.java
+++ b/src/main/java/coffeandcommit/crema/domain/reservation/enums/Status.java
@@ -11,7 +11,6 @@ public enum Status {
 
     PENDING,
     CONFIRMED,
-    CANCELLED,
-    REJECTED
+    COMPLETED
 
 }

--- a/src/main/java/coffeandcommit/crema/domain/review/entity/Review.java
+++ b/src/main/java/coffeandcommit/crema/domain/review/entity/Review.java
@@ -18,8 +18,8 @@ public class Review extends BaseEntity{
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "reservation_id", nullable = false)
+    @OneToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "reservation_id", nullable = false, unique = true)
     private Reservation reservationId; // FK, 예약 ID
 
     @Column(nullable = false)

--- a/src/main/java/coffeandcommit/crema/domain/review/entity/Review.java
+++ b/src/main/java/coffeandcommit/crema/domain/review/entity/Review.java
@@ -18,7 +18,7 @@ public class Review extends BaseEntity{
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "reservation_id", nullable = false)
     private Reservation reservationId; // FK, 예약 ID
 

--- a/src/main/java/coffeandcommit/crema/domain/review/entity/ReviewExperience.java
+++ b/src/main/java/coffeandcommit/crema/domain/review/entity/ReviewExperience.java
@@ -1,0 +1,29 @@
+package coffeandcommit.crema.domain.review.entity;
+
+import coffeandcommit.crema.domain.guide.entity.ExperienceGroup;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder(toBuilder = true)
+@Table(name = "review_experience")
+public class ReviewExperience {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "review_id", nullable = false)
+    private Review reviewId; // FK, 후기 ID
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "experience_group_id", nullable = false)
+    private ExperienceGroup experienceGroupId; // FK, 경험 대주제 ID
+
+    @Column(nullable = false)
+    private boolean thumbsUp; // 좋아요 여부
+}

--- a/src/main/java/coffeandcommit/crema/domain/review/entity/ReviewExperience.java
+++ b/src/main/java/coffeandcommit/crema/domain/review/entity/ReviewExperience.java
@@ -37,6 +37,6 @@ public class ReviewExperience extends BaseEntity {
     @JoinColumn(name = "experience_group_id", nullable = false)
     private ExperienceGroup experienceGroupId; // FK, 경험 대주제 ID
 
-    @Column(nullable = false)
+    @Column(name = "thumbs_up", nullable = false)
     private boolean thumbsUp; // 좋아요 여부
 }

--- a/src/main/java/coffeandcommit/crema/domain/review/entity/ReviewExperience.java
+++ b/src/main/java/coffeandcommit/crema/domain/review/entity/ReviewExperience.java
@@ -1,6 +1,7 @@
 package coffeandcommit.crema.domain.review.entity;
 
 import coffeandcommit.crema.domain.guide.entity.ExperienceGroup;
+import coffeandcommit.crema.global.common.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -9,18 +10,30 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder(toBuilder = true)
-@Table(name = "review_experience")
-public class ReviewExperience {
+@Table(
+    name = "review_experience",
+    uniqueConstraints = {
+        @UniqueConstraint(
+            name = "uk_review_experience_review_group",
+            columnNames = {"review_id", "experience_group_id"}
+        )
+    },
+    indexes = {
+        @Index(name = "idx_review_experience_review_id", columnList = "review_id"),
+        @Index(name = "idx_review_experience_experience_group_id", columnList = "experience_group_id")
+    }
+)
+public class ReviewExperience extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "review_id", nullable = false)
     private Review reviewId; // FK, 후기 ID
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "experience_group_id", nullable = false)
     private ExperienceGroup experienceGroupId; // FK, 경험 대주제 ID
 

--- a/src/main/java/coffeandcommit/crema/domain/survey/entity/Survey.java
+++ b/src/main/java/coffeandcommit/crema/domain/survey/entity/Survey.java
@@ -4,6 +4,8 @@ import coffeandcommit.crema.global.common.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.time.LocalDateTime;
+
 
 @Entity
 @Getter
@@ -20,10 +22,10 @@ public class Survey extends BaseEntity{
     @Column(nullable = false, length = 2048)
     private String fileUploadURL;
 
-    @Column(nullable = false)
-    private String talkSubject; // 대화주제
-
     @Column(columnDefinition = "TEXT")
-    private String subjectDescription; // 직접입력 주제
+    private String messageToGuide; // 직접입력 주제
+
+    @Column(nullable = false)
+    private LocalDateTime preferred_date; // 희망 날짜
 
 }

--- a/src/main/java/coffeandcommit/crema/domain/survey/entity/Survey.java
+++ b/src/main/java/coffeandcommit/crema/domain/survey/entity/Survey.java
@@ -22,7 +22,7 @@ public class Survey extends BaseEntity{
     @Column(nullable = false, length = 2048)
     private String fileUploadURL;
 
-    @Column(columnDefinition = "TEXT")
+    @Column(nullable = true)
     private String messageToGuide; // 직접입력 주제
 
     @Column(name = "preferred_date",nullable = false)

--- a/src/main/java/coffeandcommit/crema/domain/survey/entity/Survey.java
+++ b/src/main/java/coffeandcommit/crema/domain/survey/entity/Survey.java
@@ -25,7 +25,7 @@ public class Survey extends BaseEntity{
     @Column(columnDefinition = "TEXT")
     private String messageToGuide; // 직접입력 주제
 
-    @Column(nullable = false)
-    private LocalDateTime preferred_date; // 희망 날짜
+    @Column(name = "preferred_date",nullable = false)
+    private LocalDateTime preferredDate; // 희망 날짜
 
 }


### PR DESCRIPTION
# 🚀 What’s this PR about?

- 경험 주제와 관련된 entity를 추가했습니다.

# 🛠️ What’s been done?

- ReviewExperience Entity 추가 및 필드 확장
- ReviewExperience 엔티티 생성 (review_id, experience_group_id, thumbsUp 필드 포함)
- ExperienceDetail 엔티티에 필드 추가 (who, solution, how)

# 🧪 Testing Details

- X

# 👀 Checkpoints for Reviewers



# 📚 References & Resources


# 🎯 Related Issues
- close#27 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 리뷰에 경험 피드백(엄지척)을 저장·조회할 수 있는 기능이 추가되었습니다.
- 리팩터
  - 경험 상세가 단일 필드에서 ‘누가(Who)’, ‘해결책(Solution)’, ‘방법(How)’으로 분리되어 입력·표시가 더 명확해졌습니다.
  - 회의실·예약·리뷰 간 일부 연관관계가 다대일에서 일대일로 변경되어 데이터 연결 방식이 조정되었습니다.
  - 설문 관련 필드가 재구성되고 선호일(preferred_date)이 추가되었습니다.
  - 예약 상태(enum) 중 일부 상태명이 조정되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->