### PR TITLE
[Feat] 테스트용 계정 생성/로그인/삭제 api 구현 + global/httpTest 패키지 생성

### DIFF
--- a/src/main/java/coffeandcommit/crema/domain/member/repository/MemberRepository.java
+++ b/src/main/java/coffeandcommit/crema/domain/member/repository/MemberRepository.java
@@ -2,8 +2,10 @@ package coffeandcommit.crema.domain.member.repository;
 
 import coffeandcommit.crema.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
@@ -20,4 +22,14 @@ public interface MemberRepository extends JpaRepository<Member, String> {
 
     @Query("SELECT CASE WHEN COUNT(m) > 0 THEN true ELSE false END FROM Member m WHERE m.nickname = :nickname AND m.isDeleted = false")
     boolean existsByNicknameAndIsDeletedFalse(@Param("nickname") String nickname);
+
+    // native 쿼리, 테스트 계정 일괄 하드삭제용 (is_deleted 조건 무시용)
+    @Modifying
+    @Transactional
+    @Query(value = """
+    DELETE FROM member 
+    WHERE (nickname LIKE 'rookie_%' OR nickname LIKE 'guide_%')
+    AND provider = 'test'
+    """, nativeQuery = true)
+    int deleteTestAccountsNative();
 }

--- a/src/main/java/coffeandcommit/crema/global/auth/config/SecurityConfig.java
+++ b/src/main/java/coffeandcommit/crema/global/auth/config/SecurityConfig.java
@@ -45,7 +45,8 @@ public class SecurityConfig {
                         .requestMatchers(
                                 "/api/auth/status",
                                 "/api/auth/refresh",
-                                "/api/member/check/**", // 닉네임 중복 체크만 남김
+                                "/api/member/check/**",
+                                "/api/test/auth/**",
                                 "/oauth2/**",
                                 "/login/oauth2/**",
                                 // Swagger UI

--- a/src/main/java/coffeandcommit/crema/global/auth/controller/TestAuthController.java
+++ b/src/main/java/coffeandcommit/crema/global/auth/controller/TestAuthController.java
@@ -1,0 +1,165 @@
+package coffeandcommit.crema.global.auth.controller;
+
+import coffeandcommit.crema.domain.member.entity.Member;
+import coffeandcommit.crema.domain.member.enums.MemberRole;
+import coffeandcommit.crema.domain.member.repository.MemberRepository;
+import coffeandcommit.crema.global.auth.jwt.JwtTokenProvider;
+import coffeandcommit.crema.global.common.exception.BaseException;
+import coffeandcommit.crema.global.common.exception.code.ErrorStatus;
+import coffeandcommit.crema.global.common.exception.response.ApiResponse;
+import coffeandcommit.crema.global.common.exception.code.SuccessStatus;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Profile;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.UUID;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/test/auth")
+@RequiredArgsConstructor
+@Profile("local") // 로컬 환경에서만 활성화
+@Tag(name = "Test Auth API", description = "로컬 개발용 테스트 인증 API (local 프로필에서만 활성화)")
+public class TestAuthController {
+
+    private final MemberRepository memberRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Operation(summary = "루키 테스트 계정 생성", description = "로컬 개발용 루키 테스트 계정을 생성합니다.")
+    @PostMapping("/create-rookie")
+    public ApiResponse<Map<String, String>> createRookieAccount() {
+        String nickname = generateNickname("rookie");
+        Member member = createTestMember(nickname, MemberRole.ROOKIE);
+
+        Map<String, String> response = new LinkedHashMap<>();
+        response.put("memberId", member.getId());
+        response.put("nickname", member.getNickname());
+        response.put("role", member.getRole().name());
+
+        log.info("테스트 루키 계정 생성: {}", nickname);
+        return ApiResponse.onSuccess(SuccessStatus.CREATED, response);
+    }
+
+    @Operation(summary = "가이드 테스트 계정 생성", description = "로컬 개발용 가이드 테스트 계정을 생성합니다.")
+    @PostMapping("/create-guide")
+    public ApiResponse<Map<String, String>> createGuideAccount() {
+        String nickname = generateNickname("guide");
+        Member member = createTestMember(nickname, MemberRole.GUIDE);
+
+        Map<String, String> response = new LinkedHashMap<>();
+        response.put("memberId", member.getId());
+        response.put("nickname", member.getNickname());
+        response.put("role", member.getRole().name());
+
+        log.info("테스트 가이드 계정 생성: {}", nickname);
+        return ApiResponse.onSuccess(SuccessStatus.CREATED, response);
+    }
+
+    @Operation(summary = "테스트 계정 로그인", description = "생성된 테스트 계정으로 로그인하여 JWT 토큰을 발급받습니다.")
+    @PostMapping("/login")
+    public ApiResponse<Map<String, String>> loginTestAccount(
+            @Parameter(description = "테스트 계정 닉네임 (예: rookie_12345678, guide_12345678)", required = true)
+            @RequestBody Map<String, String> request) {
+
+        String nickname = request.get("nickname");
+
+        if (nickname == null || nickname.trim().isEmpty()) {
+            throw new BaseException(ErrorStatus.BAD_REQUEST);
+        }
+
+        // 테스트 계정인지 확인
+        if (!isTestAccount(nickname)) {
+            throw new BaseException(ErrorStatus.BAD_REQUEST);
+        }
+
+        Member member = memberRepository.findByNicknameAndIsDeletedFalse(nickname)
+                .orElseThrow(() -> new BaseException(ErrorStatus.MEMBER_NOT_FOUND));
+
+        // JWT 토큰 생성
+        String accessToken = jwtTokenProvider.createAccessToken(member.getId());
+        String refreshToken = jwtTokenProvider.createRefreshToken(member.getId());
+
+        Map<String, String> response = new LinkedHashMap<>();
+        response.put("tokenType", "Bearer");
+        response.put("accessToken", accessToken);
+        response.put("refreshToken", refreshToken);
+        response.put("memberId", member.getId());
+        response.put("nickname", member.getNickname());
+        response.put("role", member.getRole().name());
+
+        log.info("테스트 계정 로그인: {}", nickname);
+        return ApiResponse.onSuccess(SuccessStatus.OK, response);
+    }
+
+    @Operation(summary = "테스트 계정 일괄 삭제", description = "생성된 모든 테스트 계정을 삭제합니다.")
+    @DeleteMapping("/cleanup")
+    public ApiResponse<Map<String, Object>> cleanupTestAccounts() {
+        // rookie_* 또는 guide_* 패턴의 테스트 계정 조회
+        var testMembers = memberRepository.findAll().stream()
+                .filter(member -> !Boolean.TRUE.equals(member.getIsDeleted()))
+                .filter(member -> "test".equals(member.getProvider()))
+                .filter(member -> isTestAccount(member.getNickname()))
+                .toList();
+
+        int deletedCount = testMembers.size();
+
+        // 소프트 삭제 처리
+        testMembers.forEach(Member::softDelete);
+        memberRepository.saveAll(testMembers);
+
+        Map<String, Object> response = new LinkedHashMap<>();
+        response.put("deletedCount", deletedCount);
+        response.put("message", deletedCount + "개의 테스트 계정이 삭제되었습니다.");
+
+        log.info("테스트 계정 일괄 삭제 완료: {}개", deletedCount);
+        return ApiResponse.onSuccess(SuccessStatus.OK, response);
+    }
+
+    // === Private Helper Methods ===
+
+    /**
+     * 고유한 닉네임 생성 (role_uuid 형식)
+     */
+    private String generateNickname(String rolePrefix) {
+        String uuid = UUID.randomUUID().toString().substring(0, 8);
+        String nickname = rolePrefix + "_" + uuid;
+
+        // 중복 체크 (만약의 경우를 대비)
+        while (memberRepository.existsByNicknameAndIsDeletedFalse(nickname)) {
+            uuid = UUID.randomUUID().toString().substring(0, 8);
+            nickname = rolePrefix + "_" + uuid;
+        }
+
+        return nickname;
+    }
+
+    /**
+     * 테스트 멤버 생성
+     */
+    private Member createTestMember(String nickname, MemberRole role) {
+        Member member = Member.builder()
+                .id(UUID.randomUUID().toString())
+                .nickname(nickname)
+                .role(role)
+                .point(0)
+                .provider("test") // 테스트 계정 구분자
+                .providerId(nickname) // 테스트용으로 닉네임과 동일하게 설정
+                .build();
+
+        return memberRepository.save(member);
+    }
+
+    /**
+     * 테스트 계정인지 확인 (rookie_* 또는 guide_* 패턴)
+     */
+    private boolean isTestAccount(String nickname) {
+        return nickname != null &&
+                (nickname.startsWith("rookie_") || nickname.startsWith("guide_"));
+    }
+}

--- a/src/main/java/coffeandcommit/crema/global/httpTest/TestAuthController.http
+++ b/src/main/java/coffeandcommit/crema/global/httpTest/TestAuthController.http
@@ -1,0 +1,22 @@
+### 1. 루키 테스트 계정 생성
+POST http://localhost:8080/api/test/auth/create-rookie
+Content-Type: application/json
+
+### 2. 가이드 테스트 계정 생성
+POST http://localhost:8080/api/test/auth/create-guide
+Content-Type: application/json
+
+### 3. 테스트 계정 로그인 (🔥🔥🔥🔥🔥🔥1번 또는 2번으로 새로 생성된 계정의 닉네임을 수동으로 입력해야 함🔥🔥🔥🔥🔥🔥)
+POST http://localhost:8080/api/test/auth/login
+Content-Type: application/json
+
+{
+  "nickname": "rookie_1234예시5678"
+}
+
+### 4. JWT 토큰으로 내 정보 조회 테스트 (3번 에서 받은 accessToken을 Bearer 뒤에 붙여넣기, 다른 도메인에서도 token 사용 가능한지 확인용)
+GET http://localhost:8080/api/member/me
+Authorization: Bearer ~~~
+
+### 5. 테스트 계정 일괄 삭제
+DELETE http://localhost:8080/api/test/auth/cleanup

--- a/src/main/java/coffeandcommit/crema/global/httpTest/TestAuthController.http
+++ b/src/main/java/coffeandcommit/crema/global/httpTest/TestAuthController.http
@@ -11,7 +11,7 @@ POST http://localhost:8080/api/test/auth/login
 Content-Type: application/json
 
 {
-  "nickname": "rookie_1234예시5678"
+  "nickname": "rookie_4926예제6f5d"
 }
 
 ### 4. JWT 토큰으로 내 정보 조회 테스트 (3번 에서 받은 accessToken을 Bearer 뒤에 붙여넣기, 다른 도메인에서도 token 사용 가능한지 확인용)


### PR DESCRIPTION
# 🚀 What’s this PR about?

### 1. 테스트용 계정 생성/로그인/삭제 api 구현
- OAuth2 로그인을 우회한 테스트용 더미 계정 생성로직 구현 (local용)

### 2. .http 관련
- global/common/httpTest 폴더 생성 (테스트를 용이하게 하기 위한 `.http` 파일은 앞으로 여기다 모아주시면 감사하겠습니다!)
- 테스트 계정 생성/로그인/삭제 관련된 api 및 request body 내용은 `global/common/httpTest/TestAuthController.http` 에 정리해두었습니다.

# 🛠️ What’s been done?
## 테스트 계정과 관련된 아래 api들은 `local 환경`에서만 작동합니다!

1. 새 테스트 계정 생성(role 별로 rookie/guide 생성 나뉨):
- POST /api/test/auth/create-rookie
- POST /api/test/auth/create-guide

2. 테스트 계정 로그인 (1번에서 생성된 테스트 계정의 닉네임 body에 첨부):
- POST /api/test/auth/login
{
    "nickname": "rookie_d9a0예시7c83"
}

3. 테스트 계정만 일괄 하드삭제:
- DELETE /api/test/auth/cleanup

# 🧪 Testing Details
<img width="868" height="1056" alt="루키 테스트 계정 생성" src="https://github.com/user-attachments/assets/bcb22ce4-b304-4edd-a7e7-d48568d61e8f" />
[루키 테스트 계정 생성 성공]

<img width="868" height="1056" alt="가이드 테스트 계정 생성" src="https://github.com/user-attachments/assets/9c6377c5-030c-4ed1-9473-b38bb7214812" />
[가이드 테스트 계정 생성 성공]

<img width="868" height="1056" alt="테스트 계정 로그인" src="https://github.com/user-attachments/assets/08a7d505-5ca9-4b26-a2c1-afe99c0d7cd2" />
[테스트 계정 로그인 성공]

<img width="868" height="1056" alt="테스트 계정 일괄 하드삭제" src="https://github.com/user-attachments/assets/ffd11bf9-c350-4e4a-afff-594cce8af041" />
[테스트 계정 일괄 하드삭제 성공]

# 👀 Checkpoints for Reviewers
- 이 pr이 머지되고 나서는  `/api/test/auth/` 경로의 더미 계정 생성/로그인/삭제 api를 통해 다른 도메인들 테스트 해주시면 됩니다! 
- local 환경에서만 가능하니 참고 부탁드립니다.

# 🎯 Related Issues
closes #24 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 로컬 전용 테스트 인증 엔드포인트 추가: 루키/가이드 계정 생성, 테스트 계정 로그인(액세스/리프레시 토큰 발급), 테스트 계정 정리(삭제, 하드 삭제 방식).
  - 테스트 엔드포인트는 인증 없이 접근 가능하도록 공개 경로에 추가됨.
- 문서
  - 단계별 HTTP 요청 스크립트 추가: 계정 생성 → 로그인 → 내 정보 조회 → 정리.
- 작업
  - 보안 설정 업데이트로 로컬 테스트 인증 경로의 공개 접근 허용.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->