### PR TITLE
[Feat] aws s3 연동

### DIFF
--- a/src/main/java/coffeandcommit/crema/domain/member/repository/MemberRepository.java
+++ b/src/main/java/coffeandcommit/crema/domain/member/repository/MemberRepository.java
@@ -2,8 +2,10 @@ package coffeandcommit.crema.domain.member.repository;
 
 import coffeandcommit.crema.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
@@ -20,4 +22,14 @@ public interface MemberRepository extends JpaRepository<Member, String> {
 
     @Query("SELECT CASE WHEN COUNT(m) > 0 THEN true ELSE false END FROM Member m WHERE m.nickname = :nickname AND m.isDeleted = false")
     boolean existsByNicknameAndIsDeletedFalse(@Param("nickname") String nickname);
+
+    // native 쿼리, 테스트 계정 일괄 하드삭제용 (is_deleted 조건 무시용)
+    @Modifying
+    @Transactional
+    @Query(value = """
+    DELETE FROM member 
+    WHERE (nickname LIKE 'rookie_%' OR nickname LIKE 'guide_%')
+    AND provider = 'test'
+    """, nativeQuery = true)
+    int deleteTestAccountsNative();
 }

--- a/src/main/java/coffeandcommit/crema/global/AWS/config/S3Config.java
+++ b/src/main/java/coffeandcommit/crema/global/AWS/config/S3Config.java
@@ -3,6 +3,7 @@ package coffeandcommit.crema.global.AWS.config;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
@@ -11,14 +12,17 @@ import software.amazon.awssdk.services.s3.S3Client;
 @Configuration
 public class S3Config {
 
-    @Value("${cloud.aws.credentials.accessKey}")
+    @Value("${cloud.aws.credentials.access-key}")
     private String accessKey;
-    @Value("${cloud.aws.credentials.secretKey}")
+
+    @Value("${cloud.aws.credentials.secret-key}")
     private String secretKey;
+
     @Value("${cloud.aws.region.static}")
     private String region;
 
     @Bean
+    @Primary  // Spring Cloud AWS와 충돌 방지
     public S3Client s3Client(){
         AwsBasicCredentials awsCredentials = AwsBasicCredentials.create(accessKey, secretKey);
         return S3Client.builder()

--- a/src/main/java/coffeandcommit/crema/global/AWS/controller/ImageController.java
+++ b/src/main/java/coffeandcommit/crema/global/AWS/controller/ImageController.java
@@ -24,43 +24,43 @@ import org.springframework.web.multipart.MultipartFile;
 @RequiredArgsConstructor
 @Tag(name = "Image API", description = "이미지 업로드/삭제/조회 API")
 public class ImageController {
-    
+
     private final ImageService imageService;
-    
+
     @SecurityRequirement(name = "JWT")
     @Operation(
-        summary = "이미지 업로드 (범용)",
-        description = "지정된 폴더에 이미지를 업로드합니다. " +
-                     "지원 형식: JPEG, PNG, GIF, WebP (최대 10MB)"
+            summary = "이미지 업로드 (범용)",
+            description = "지정된 폴더에 이미지를 업로드합니다. " +
+                    "지원 형식: JPEG, PNG, GIF, WebP (최대 10MB)"
     )
     @PostMapping(value = "/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<Response<ImageUploadResponse>> uploadImage(
             @Parameter(description = "업로드할 이미지 파일", required = true)
             @RequestPart("image") MultipartFile image,
-            
-            @Parameter(description = "S3 폴더명 (예: study-diary-images, profile-images)", required = true)
+
+            @Parameter(description = "S3 폴더명 (예: study-diary-images, guide-posts)", required = true)
             @RequestParam("folder") String folder,
-            
+
             @AuthenticationPrincipal UserDetails userDetails) {
-        
+
         try {
             String userId = userDetails.getUsername();
             ImageUploadResponse response = imageService.uploadImage(image, folder, userId);
-            
+
             log.info("Image upload requested by user: {} to folder: {}", userId, folder);
-            
+
             return ResponseEntity.ok(Response.<ImageUploadResponse>builder()
                     .message("이미지가 성공적으로 업로드되었습니다.")
                     .data(response)
                     .build());
-                    
+
         } catch (IllegalArgumentException e) {
             log.warn("Invalid image upload request: {}", e.getMessage());
             return ResponseEntity.badRequest()
                     .body(Response.<ImageUploadResponse>builder()
                             .message("업로드 실패: " + e.getMessage())
                             .build());
-                            
+
         } catch (Exception e) {
             log.error("Image upload failed: {}", e.getMessage());
             return ResponseEntity.internalServerError()
@@ -69,100 +69,22 @@ public class ImageController {
                             .build());
         }
     }
-    
+
     @SecurityRequirement(name = "JWT")
     @Operation(
-        summary = "스터디 다이어리 이미지 업로드",
-        description = "스터디 다이어리용 이미지를 업로드합니다. (study-diary-images 폴더)"
-    )
-    @PostMapping(value = "/studydiary", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<Response<ImageUploadResponse>> uploadStudyDiaryImage(
-            @Parameter(description = "업로드할 이미지 파일", required = true)
-            @RequestPart("image") MultipartFile image,
-            
-            @AuthenticationPrincipal UserDetails userDetails) {
-        
-        try {
-            String userId = userDetails.getUsername();
-            ImageUploadResponse response = imageService.uploadStudyDiaryImage(image, userId);
-            
-            log.info("Study diary image upload requested by user: {}", userId);
-            
-            return ResponseEntity.ok(Response.<ImageUploadResponse>builder()
-                    .message("스터디 다이어리 이미지가 성공적으로 업로드되었습니다.")
-                    .data(response)
-                    .build());
-                    
-        } catch (IllegalArgumentException e) {
-            log.warn("Invalid study diary image upload request: {}", e.getMessage());
-            return ResponseEntity.badRequest()
-                    .body(Response.<ImageUploadResponse>builder()
-                            .message("업로드 실패: " + e.getMessage())
-                            .build());
-                            
-        } catch (Exception e) {
-            log.error("Study diary image upload failed: {}", e.getMessage());
-            return ResponseEntity.internalServerError()
-                    .body(Response.<ImageUploadResponse>builder()
-                            .message("이미지 업로드 중 서버 오류가 발생했습니다.")
-                            .build());
-        }
-    }
-    
-    @SecurityRequirement(name = "JWT")
-    @Operation(
-        summary = "프로필 이미지 업로드",
-        description = "프로필용 이미지를 업로드합니다. (profile-images 폴더)"
-    )
-    @PostMapping(value = "/profile", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<Response<ImageUploadResponse>> uploadProfileImage(
-            @Parameter(description = "업로드할 이미지 파일", required = true)
-            @RequestPart("image") MultipartFile image,
-            
-            @AuthenticationPrincipal UserDetails userDetails) {
-        
-        try {
-            String userId = userDetails.getUsername();
-            ImageUploadResponse response = imageService.uploadProfileImage(image, userId);
-            
-            log.info("Profile image upload requested by user: {}", userId);
-            
-            return ResponseEntity.ok(Response.<ImageUploadResponse>builder()
-                    .message("프로필 이미지가 성공적으로 업로드되었습니다.")
-                    .data(response)
-                    .build());
-                    
-        } catch (IllegalArgumentException e) {
-            log.warn("Invalid profile image upload request: {}", e.getMessage());
-            return ResponseEntity.badRequest()
-                    .body(Response.<ImageUploadResponse>builder()
-                            .message("업로드 실패: " + e.getMessage())
-                            .build());
-                            
-        } catch (Exception e) {
-            log.error("Profile image upload failed: {}", e.getMessage());
-            return ResponseEntity.internalServerError()
-                    .body(Response.<ImageUploadResponse>builder()
-                            .message("이미지 업로드 중 서버 오류가 발생했습니다.")
-                            .build());
-        }
-    }
-    
-    @SecurityRequirement(name = "JWT")
-    @Operation(
-        summary = "이미지 삭제",
-        description = "S3에서 이미지를 삭제합니다. imageKey는 전체 경로를 포함해야 합니다."
+            summary = "이미지 삭제",
+            description = "S3에서 이미지를 삭제합니다. imageKey는 전체 경로를 포함해야 합니다."
     )
     @DeleteMapping("/{imageKey:.+}")
     public ResponseEntity<Response<ImageDeleteResponse>> deleteImage(
             @Parameter(description = "삭제할 이미지의 S3 키 (예: study-diary-images/user123_20241201_image.jpg)", required = true)
             @PathVariable String imageKey,
-            
+
             @AuthenticationPrincipal UserDetails userDetails) {
-        
+
         try {
             String userId = userDetails.getUsername();
-            
+
             // 보안 검증: 자신이 업로드한 이미지만 삭제 가능
             if (!imageKey.contains(userId + "_")) {
                 log.warn("Unauthorized image deletion attempt by user: {} for imageKey: {}", userId, imageKey);
@@ -171,11 +93,11 @@ public class ImageController {
                                 .message("자신이 업로드한 이미지만 삭제할 수 있습니다.")
                                 .build());
             }
-            
+
             ImageDeleteResponse response = imageService.deleteImage(imageKey);
-            
+
             log.info("Image deletion requested by user: {} for imageKey: {}", userId, imageKey);
-            
+
             if (response.isSuccess()) {
                 return ResponseEntity.ok(Response.<ImageDeleteResponse>builder()
                         .message("이미지가 성공적으로 삭제되었습니다.")
@@ -188,7 +110,7 @@ public class ImageController {
                                 .data(response)
                                 .build());
             }
-            
+
         } catch (Exception e) {
             log.error("Image deletion failed for imageKey: {} - {}", imageKey, e.getMessage());
             return ResponseEntity.internalServerError()
@@ -197,29 +119,29 @@ public class ImageController {
                             .build());
         }
     }
-    
+
     @SecurityRequirement(name = "JWT")
     @Operation(
-        summary = "이미지 URL 조회",
-        description = "이미지의 Presigned URL을 생성합니다. (2분간 유효)"
+            summary = "이미지 URL 조회",
+            description = "이미지의 Presigned URL을 생성합니다. (2분간 유효)"
     )
     @GetMapping("/{imageKey:.+}/url")
     public ResponseEntity<Response<ImageUrlResponse>> getImageUrl(
             @Parameter(description = "조회할 이미지의 S3 키", required = true)
             @PathVariable String imageKey,
-            
+
             @AuthenticationPrincipal UserDetails userDetails) {
-        
+
         try {
             ImageUrlResponse response = imageService.getImageUrl(imageKey);
-            
+
             log.info("Image URL requested by user: {} for imageKey: {}", userDetails.getUsername(), imageKey);
-            
+
             return ResponseEntity.ok(Response.<ImageUrlResponse>builder()
                     .message("이미지 URL이 성공적으로 생성되었습니다.")
                     .data(response)
                     .build());
-                    
+
         } catch (Exception e) {
             log.error("Image URL generation failed for imageKey: {} - {}", imageKey, e.getMessage());
             return ResponseEntity.internalServerError()
@@ -228,4 +150,4 @@ public class ImageController {
                             .build());
         }
     }
-} 
+}

--- a/src/main/java/coffeandcommit/crema/global/AWS/service/ImageService.java
+++ b/src/main/java/coffeandcommit/crema/global/AWS/service/ImageService.java
@@ -19,21 +19,21 @@ import java.util.UUID;
 @RequiredArgsConstructor
 @Service
 public class ImageService {
-    
+
     private final S3Service s3Service;
-    
+
     // 허용되는 이미지 타입
     private static final List<String> ALLOWED_IMAGE_TYPES = Arrays.asList(
-        "image/jpeg", "image/jpg", "image/png", "image/gif", "image/webp"
+            "image/jpeg", "image/jpg", "image/png", "image/gif", "image/webp"
     );
-    
+
     // 최대 파일 크기 (10MB)
     private static final long MAX_FILE_SIZE = 10 * 1024 * 1024;
-    
+
     /**
-     * 이미지 업로드
+     * 이미지 업로드 (범용)
      * @param file 업로드할 이미지 파일
-     * @param folder S3 내 폴더명 (예: "study-diary-images", "profile-images")
+     * @param folder S3 내 폴더명 (예: "study-diary-images", "guide-posts")
      * @param userId 사용자 ID (파일명에 사용)
      * @return ImageUploadResponse
      */
@@ -41,20 +41,20 @@ public class ImageService {
         try {
             // 파일 검증
             validateImageFile(file);
-            
+
             // 파일명 생성
             String storedFileName = generateFileName(file.getOriginalFilename(), userId);
             String imageKey = folder + "/" + storedFileName;
-            
+
             // S3 업로드
             String imageUrl = s3Service.upload(file, imageKey);
-            
+
             log.info("Image uploaded successfully: {} -> {}", file.getOriginalFilename(), imageKey);
-            
+
             // 마크다운 이미지 링크 생성
-            String markdownImageLink = String.format("![%s](%s)", 
-                file.getOriginalFilename(), imageUrl);
-            
+            String markdownImageLink = String.format("![%s](%s)",
+                    file.getOriginalFilename(), imageUrl);
+
             return ImageUploadResponse.builder()
                     .imageKey(imageKey)
                     .imageUrl(imageUrl)
@@ -64,27 +64,20 @@ public class ImageService {
                     .contentType(file.getContentType())
                     .markdownImageLink(markdownImageLink)
                     .build();
-                    
+
         } catch (IOException e) {
             log.error("Failed to upload image: {}", e.getMessage());
             throw new RuntimeException("이미지 업로드 중 오류가 발생했습니다: " + e.getMessage());
         }
     }
-    
+
     /**
-     * 스터디 다이어리 이미지 업로드 (편의 메소드)
-     */
-    public ImageUploadResponse uploadStudyDiaryImage(MultipartFile file, String userId) {
-        return uploadImage(file, "study-diary-images", userId);
-    }
-    
-    /**
-     * 프로필 이미지 업로드 (편의 메소드)
+     * 프로필 이미지 업로드 (MemberProfileService에서 사용)
      */
     public ImageUploadResponse uploadProfileImage(MultipartFile file, String userId) {
         return uploadImage(file, "profile-images", userId);
     }
-    
+
     /**
      * 이미지 삭제
      * @param imageKey 삭제할 이미지의 S3 키
@@ -93,18 +86,18 @@ public class ImageService {
     public ImageDeleteResponse deleteImage(String imageKey) {
         try {
             s3Service.delete(imageKey);
-            
+
             log.info("Image deleted successfully: {}", imageKey);
-            
+
             return ImageDeleteResponse.builder()
                     .deletedImageKey(imageKey)
                     .success(true)
                     .deletedAt(LocalDateTime.now().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME))
                     .build();
-                    
+
         } catch (Exception e) {
             log.error("Failed to delete image: {} - {}", imageKey, e.getMessage());
-            
+
             return ImageDeleteResponse.builder()
                     .deletedImageKey(imageKey)
                     .success(false)
@@ -112,7 +105,7 @@ public class ImageService {
                     .build();
         }
     }
-    
+
     /**
      * 이미지 Presigned URL 조회
      * @param imageKey 조회할 이미지의 S3 키
@@ -121,20 +114,20 @@ public class ImageService {
     public ImageUrlResponse getImageUrl(String imageKey) {
         try {
             String presignedUrl = s3Service.getPresignedURL(imageKey);
-            
+
             return ImageUrlResponse.builder()
                     .imageKey(imageKey)
                     .presignedUrl(presignedUrl)
                     .expirationMinutes(2)
                     .generatedAt(LocalDateTime.now().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME))
                     .build();
-                    
+
         } catch (Exception e) {
             log.error("Failed to generate presigned URL for image: {} - {}", imageKey, e.getMessage());
             throw new RuntimeException("이미지 URL 생성 중 오류가 발생했습니다: " + e.getMessage());
         }
     }
-    
+
     /**
      * 이미지 파일 검증
      */
@@ -142,30 +135,30 @@ public class ImageService {
         if (file == null || file.isEmpty()) {
             throw new IllegalArgumentException("이미지 파일이 비어있습니다.");
         }
-        
+
         // 파일 크기 검증
         if (file.getSize() > MAX_FILE_SIZE) {
             throw new IllegalArgumentException("파일 크기가 너무 큽니다. 최대 10MB까지 업로드 가능합니다.");
         }
-        
+
         // 파일 타입 검증
         String contentType = file.getContentType();
         if (contentType == null || !ALLOWED_IMAGE_TYPES.contains(contentType.toLowerCase())) {
             throw new IllegalArgumentException("지원하지 않는 이미지 형식입니다. (지원 형식: JPEG, PNG, GIF, WebP)");
         }
-        
+
         // 파일명 검증
         String originalFilename = file.getOriginalFilename();
         if (originalFilename == null || originalFilename.trim().isEmpty()) {
             throw new IllegalArgumentException("파일명이 유효하지 않습니다.");
         }
-        
+
         // 확장자 검증
         if (!originalFilename.contains(".")) {
             throw new IllegalArgumentException("파일 확장자가 없습니다.");
         }
     }
-    
+
     /**
      * 고유한 파일명 생성
      * 형식: {userId}_{timestamp}_{uuid}_{originalName}
@@ -173,7 +166,7 @@ public class ImageService {
     private String generateFileName(String originalFilename, String userId) {
         String timestamp = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss"));
         String uuid = UUID.randomUUID().toString().substring(0, 8);
-        
+
         // 원본 파일명에서 확장자 추출
         String extension = "";
         int lastDotIndex = originalFilename.lastIndexOf(".");
@@ -181,15 +174,15 @@ public class ImageService {
             extension = originalFilename.substring(lastDotIndex);
             originalFilename = originalFilename.substring(0, lastDotIndex);
         }
-        
+
         // 파일명 길이 제한 (S3 키 길이 제한 고려)
         if (originalFilename.length() > 30) {
             originalFilename = originalFilename.substring(0, 30);
         }
-        
+
         // 특수문자 제거 및 안전한 파일명 생성
         String safeName = originalFilename.replaceAll("[^a-zA-Z0-9가-힣._-]", "_");
-        
+
         return String.format("%s_%s_%s_%s%s", userId, timestamp, uuid, safeName, extension);
     }
-} 
+}

--- a/src/main/java/coffeandcommit/crema/global/auth/config/SecurityConfig.java
+++ b/src/main/java/coffeandcommit/crema/global/auth/config/SecurityConfig.java
@@ -45,7 +45,8 @@ public class SecurityConfig {
                         .requestMatchers(
                                 "/api/auth/status",
                                 "/api/auth/refresh",
-                                "/api/member/check/**", // 닉네임 중복 체크만 남김
+                                "/api/member/check/**",
+                                "/api/test/auth/**",
                                 "/oauth2/**",
                                 "/login/oauth2/**",
                                 // Swagger UI

--- a/src/main/java/coffeandcommit/crema/global/auth/controller/TestAuthController.java
+++ b/src/main/java/coffeandcommit/crema/global/auth/controller/TestAuthController.java
@@ -1,0 +1,159 @@
+package coffeandcommit.crema.global.auth.controller;
+
+import coffeandcommit.crema.domain.member.entity.Member;
+import coffeandcommit.crema.domain.member.enums.MemberRole;
+import coffeandcommit.crema.domain.member.repository.MemberRepository;
+import coffeandcommit.crema.global.auth.jwt.JwtTokenProvider;
+import coffeandcommit.crema.global.common.exception.BaseException;
+import coffeandcommit.crema.global.common.exception.code.ErrorStatus;
+import coffeandcommit.crema.global.common.exception.response.ApiResponse;
+import coffeandcommit.crema.global.common.exception.code.SuccessStatus;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Profile;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.UUID;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/test/auth")
+@RequiredArgsConstructor
+@Profile("local")
+@Tag(name = "Test Auth API", description = "로컬 개발용 테스트 인증 API (local 프로필에서만 활성화)")
+public class TestAuthController {
+
+    private final MemberRepository memberRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Operation(summary = "루키 테스트 계정 생성", description = "로컬 개발용 루키 테스트 계정을 생성합니다.")
+    @PostMapping("/create-rookie")
+    public ApiResponse<Map<String, String>> createRookieAccount() {
+        String nickname = generateNickname("rookie");
+        Member member = createTestMember(nickname, MemberRole.ROOKIE);
+
+        Map<String, String> response = new LinkedHashMap<>();
+        response.put("memberId", member.getId());
+        response.put("nickname", member.getNickname());
+        response.put("role", member.getRole().name());
+
+        log.info("테스트 루키 계정 생성: {}", nickname);
+        return ApiResponse.onSuccess(SuccessStatus.CREATED, response);
+    }
+
+    @Operation(summary = "가이드 테스트 계정 생성", description = "로컬 개발용 가이드 테스트 계정을 생성합니다.")
+    @PostMapping("/create-guide")
+    public ApiResponse<Map<String, String>> createGuideAccount() {
+        String nickname = generateNickname("guide");
+        Member member = createTestMember(nickname, MemberRole.GUIDE);
+
+        Map<String, String> response = new LinkedHashMap<>();
+        response.put("memberId", member.getId());
+        response.put("nickname", member.getNickname());
+        response.put("role", member.getRole().name());
+
+        log.info("테스트 가이드 계정 생성: {}", nickname);
+        return ApiResponse.onSuccess(SuccessStatus.CREATED, response);
+    }
+
+    @Operation(summary = "테스트 계정 로그인", description = "생성된 테스트 계정으로 로그인하여 JWT 토큰을 발급받습니다.")
+    @PostMapping("/login")
+    public ApiResponse<Map<String, String>> loginTestAccount(
+            @Parameter(description = "테스트 계정 닉네임 (예: rookie_12345678, guide_12345678)", required = true)
+            @RequestBody Map<String, String> request) {
+
+        String nickname = request.get("nickname");
+
+        if (nickname == null || nickname.trim().isEmpty()) {
+            throw new BaseException(ErrorStatus.BAD_REQUEST);
+        }
+
+        if (!isTestAccount(nickname)) {
+            throw new BaseException(ErrorStatus.BAD_REQUEST);
+        }
+
+        Member member = memberRepository.findByNicknameAndIsDeletedFalse(nickname)
+                .orElseThrow(() -> new BaseException(ErrorStatus.MEMBER_NOT_FOUND));
+
+        String accessToken = jwtTokenProvider.createAccessToken(member.getId());
+        String refreshToken = jwtTokenProvider.createRefreshToken(member.getId());
+
+        Map<String, String> response = new LinkedHashMap<>();
+        response.put("accessToken", accessToken);
+        response.put("refreshToken", refreshToken);
+        response.put("memberId", member.getId());
+        response.put("nickname", member.getNickname());
+        response.put("role", member.getRole().name());
+        response.put("tokenType", "Bearer");
+
+        log.info("테스트 계정 로그인: {}", nickname);
+        return ApiResponse.onSuccess(SuccessStatus.OK, response);
+    }
+
+    @Operation(summary = "테스트 계정 일괄 삭제", description = "생성된 모든 테스트 계정을 완전 삭제합니다.")
+    @DeleteMapping("/cleanup")
+    public ApiResponse<Map<String, Object>> cleanupTestAccounts() {
+        int deletedCount = memberRepository.deleteTestAccountsNative();
+
+        log.info("테스트 계정 완전 삭제 완료: {}개", deletedCount);
+
+        Map<String, Object> response = new LinkedHashMap<>();
+        response.put("deletedCount", deletedCount);
+        response.put("message", deletedCount + "개의 테스트 계정이 완전 삭제되었습니다.");
+
+        return ApiResponse.onSuccess(SuccessStatus.OK, response);
+    }
+
+    private String generateNickname(String rolePrefix) {
+        for (int i = 0; i < 5; i++) {
+            String uuid = UUID.randomUUID().toString().substring(0, 8);
+            String nickname = rolePrefix + "_" + uuid;
+
+            if (!memberRepository.existsByNicknameAndIsDeletedFalse(nickname)) {
+                return nickname;
+            }
+        }
+
+        throw new BaseException(ErrorStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    private Member createTestMember(String nickname, MemberRole role) {
+        try {
+            Member member = Member.builder()
+                    .id(UUID.randomUUID().toString())
+                    .nickname(nickname)
+                    .role(role)
+                    .point(0)
+                    .provider("test")
+                    .providerId(nickname)
+                    .build();
+
+            return memberRepository.saveAndFlush(member);
+
+        } catch (Exception e) {
+            log.warn("테스트 계정 생성 실패, 닉네임 재생성 후 재시도: {}", nickname);
+            String newNickname = generateNickname(role == MemberRole.ROOKIE ? "rookie" : "guide");
+
+            Member member = Member.builder()
+                    .id(UUID.randomUUID().toString())
+                    .nickname(newNickname)
+                    .role(role)
+                    .point(0)
+                    .provider("test")
+                    .providerId(newNickname)
+                    .build();
+
+            return memberRepository.save(member);
+        }
+    }
+
+    private boolean isTestAccount(String nickname) {
+        return nickname != null &&
+                (nickname.startsWith("rookie_") || nickname.startsWith("guide_"));
+    }
+}

--- a/src/main/java/coffeandcommit/crema/global/httpTest/TestAuthController.http
+++ b/src/main/java/coffeandcommit/crema/global/httpTest/TestAuthController.http
@@ -1,0 +1,22 @@
+### 1. 루키 테스트 계정 생성
+POST http://localhost:8080/api/test/auth/create-rookie
+Content-Type: application/json
+
+### 2. 가이드 테스트 계정 생성
+POST http://localhost:8080/api/test/auth/create-guide
+Content-Type: application/json
+
+### 3. 테스트 계정 로그인 (🔥🔥🔥🔥🔥🔥1번 또는 2번으로 새로 생성된 계정의 닉네임을 수동으로 입력해야 함🔥🔥🔥🔥🔥🔥)
+POST http://localhost:8080/api/test/auth/login
+Content-Type: application/json
+
+{
+  "nickname": "rookie_4926예제6f5d"
+}
+
+### 4. JWT 토큰으로 내 정보 조회 테스트 (3번 에서 받은 accessToken을 Bearer 뒤에 붙여넣기, 다른 도메인에서도 token 사용 가능한지 확인용)
+GET http://localhost:8080/api/member/me
+Authorization: Bearer ~~~
+
+### 5. 테스트 계정 일괄 삭제
+DELETE http://localhost:8080/api/test/auth/cleanup

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -70,6 +70,7 @@ spring:
             token-uri: https://kauth.kakao.com/oauth/token
             user-info-uri: https://kapi.kakao.com/v2/user/me
             user-name-attribute: id
+  # Spring Cloud AWS 자동설정 완전 비활성화
   autoconfigure:
     exclude:
       - io.awspring.cloud.autoconfigure.s3.S3AutoConfiguration
@@ -84,12 +85,13 @@ jwt:
   access-token-expiration: 1800000  # 30분
   refresh-token-expiration: 1209600000  # 14일
 
+# AWS S3 설정 (우리 커스텀 S3Config에서 사용)
 cloud:
   aws:
     credentials:
-      accessKey: ${AWS_ACCESS_KEY:dummy-access-key}
-      secretKey: ${AWS_SECRET_KEY:dummy-secret-key}
+      access-key: ${AWS_ACCESS_KEY}
+      secret-key: ${AWS_SECRET_KEY}
     s3:
-      bucket: ${AWS_S3_BUCKET:dummy-bucket}
+      bucket: ${AWS_S3_BUCKET}
     region:
-      static: ${AWS_REGION:ap-northeast-2}
+      static: ${AWS_REGION}


### PR DESCRIPTION
# 🚀 What’s this PR about?
- 이미지/파일 업로드에 필요한 aws s3를 백엔드와 연동합니다.

# 🛠️ What’s been done?
1. AWS S3 연동 (application.yml, .env 파일 수정)

2. 불필요한 엔드포인트 삭제
- POST /api/v1/images/profile  ->  Member API로 대체
- POST /api/v1/images/studydiary -> 기획상 불필요하게 변경됨

3. spring boot의 url 자동 인코딩 과정에서 imageKey 파싱이 의도치않게  `/ -> %2F ` 로 변하는 버그
- @PathVariable 방식을 @RequestParam 방식으로 변경하여 해결

# 🧪 Testing Details
<img width="1413" height="823" alt="프로필 사진 등록:업데이트" src="https://github.com/user-attachments/assets/3abfb063-1a61-45c1-8e95-c95265b01818" />
[member 도메인 프로필 사진 등록/업데이트 성공]

<img width="1413" height="746" alt="범용 이미지 업로드 1" src="https://github.com/user-attachments/assets/760561bb-fb2c-47f7-a40e-50cb4e9b6db3" />
<img width="1413" height="823" alt="범용 이미지 업로드 2" src="https://github.com/user-attachments/assets/a69f6773-31b5-49f3-bc62-2ae2de22fb53" />
[프로필 사진 제외 범용 이미지 업로드 성공]

<img width="1413" height="406" alt="이미지 presigned url 조회 1" src="https://github.com/user-attachments/assets/714c3e60-6acd-46f6-b08a-add2f154423a" />
<img width="1413" height="809" alt="이미지 presigned url 조회 2" src="https://github.com/user-attachments/assets/615f3de4-6425-4535-bac2-aa058ad36d37" />
[범용 이미지 presigned url 생성 및 조회 성공]

<img width="1413" height="688" alt="범용 이미지 삭제 1" src="https://github.com/user-attachments/assets/d226727b-3138-4dc3-b822-b8106d7e0ef8" />
<img width="1413" height="572" alt="범용 이미지 삭제 2" src="https://github.com/user-attachments/assets/290a766e-d361-4713-b87b-163fbf22bc05" />
[범용 이미지 삭제 성공]

# 👀 Checkpoints for Reviewers
- swagger 말고 postman과 intellij의 http 클라이언트에서도 이미지 업로드 테스트 가능하다 합니다.

# 🎯 Related Issues
closes #22 
