### PR TITLE
[refactor] member_id에 들어가는 UUID 를 8글자로 제한

### DIFF
--- a/src/main/java/coffeandcommit/crema/domain/member/service/MemberService.java
+++ b/src/main/java/coffeandcommit/crema/domain/member/service/MemberService.java
@@ -13,6 +13,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.UUID;
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -22,6 +24,28 @@ public class MemberService {
     private final MemberRepository memberRepository;
     private final MemberMapper memberMapper;
     private final MemberProfileService memberProfileService;
+
+    /**
+     * 8글자 UUID 생성 (중복 체크 포함)
+     */
+    public String generateId() {
+        String id;
+        int attempts = 0;
+        final int maxAttempts = 10; // 무한 루프 방지
+
+        do {
+            id = UUID.randomUUID().toString().replace("-", "").substring(0, 8).toLowerCase();
+            attempts++;
+
+            if (attempts >= maxAttempts) {
+                log.error("Failed to generate unique member ID after {} attempts", maxAttempts);
+                throw new BaseException(ErrorStatus.INTERNAL_SERVER_ERROR);
+            }
+        } while (memberRepository.existsById(id));
+
+        log.debug("Generated unique member ID: {} (attempts: {})", id, attempts);
+        return id;
+    }
 
     /**
      * ID로 회원 조회 - 본인용 (모든 정보 포함)

--- a/src/main/java/coffeandcommit/crema/global/auth/controller/TestAuthController.java
+++ b/src/main/java/coffeandcommit/crema/global/auth/controller/TestAuthController.java
@@ -3,6 +3,7 @@ package coffeandcommit.crema.global.auth.controller;
 import coffeandcommit.crema.domain.member.entity.Member;
 import coffeandcommit.crema.domain.member.enums.MemberRole;
 import coffeandcommit.crema.domain.member.repository.MemberRepository;
+import coffeandcommit.crema.domain.member.service.MemberService;
 import coffeandcommit.crema.global.auth.jwt.JwtTokenProvider;
 import coffeandcommit.crema.global.common.exception.BaseException;
 import coffeandcommit.crema.global.common.exception.code.ErrorStatus;
@@ -30,6 +31,7 @@ public class TestAuthController {
 
     private final MemberRepository memberRepository;
     private final JwtTokenProvider jwtTokenProvider;
+    private final MemberService memberService; // MemberService 주입 추가
 
     @Operation(summary = "루키 테스트 계정 생성", description = "로컬 개발용 루키 테스트 계정을 생성합니다.")
     @PostMapping("/create-rookie")
@@ -124,8 +126,11 @@ public class TestAuthController {
 
     private Member createTestMember(String nickname, MemberRole role) {
         try {
+            // MemberService의 generateId() 메서드 사용
+            String memberId = memberService.generateId();
+
             Member member = Member.builder()
-                    .id(UUID.randomUUID().toString())
+                    .id(memberId) // 8글자 고유 ID 사용
                     .nickname(nickname)
                     .role(role)
                     .point(0)
@@ -139,8 +144,11 @@ public class TestAuthController {
             log.warn("테스트 계정 생성 실패, 닉네임 재생성 후 재시도: {}", nickname);
             String newNickname = generateNickname(role == MemberRole.ROOKIE ? "rookie" : "guide");
 
+            // 재시도 시에도 MemberService의 generateId() 사용
+            String memberId = memberService.generateId();
+
             Member member = Member.builder()
-                    .id(UUID.randomUUID().toString())
+                    .id(memberId) // 8글자 고유 ID 사용
                     .nickname(newNickname)
                     .role(role)
                     .point(0)

--- a/src/main/java/coffeandcommit/crema/global/auth/service/CustomOAuth2UserService.java
+++ b/src/main/java/coffeandcommit/crema/global/auth/service/CustomOAuth2UserService.java
@@ -1,6 +1,7 @@
 package coffeandcommit.crema.global.auth.service;
 
 import coffeandcommit.crema.domain.member.enums.MemberRole;
+import coffeandcommit.crema.domain.member.service.MemberService;
 import coffeandcommit.crema.global.auth.provider.GoogleOAuth2UserInfo;
 import coffeandcommit.crema.global.auth.provider.KakaoOAuth2UserInfo;
 import coffeandcommit.crema.global.auth.provider.OAuth2UserInfo;
@@ -27,6 +28,7 @@ import java.util.UUID;
 public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
     private final MemberRepository memberRepository;
+    private final MemberService memberService; // MemberService 주입 추가
 
     @Override
     @Transactional
@@ -92,8 +94,11 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
         String uniqueNickname = generateUniqueNickname(userInfo.getName());
 
+        // MemberService의 generateId() 메서드 사용
+        String memberId = memberService.generateId();
+
         Member member = Member.builder()
-                .id(UUID.randomUUID().toString())
+                .id(memberId) // 8글자 고유 ID 사용
                 .nickname(uniqueNickname)
                 .role(MemberRole.ROOKIE)
                 .point(0) // 초기 포인트
@@ -102,8 +107,8 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
                 .providerId(userInfo.getId())
                 .build();
 
-        log.info("Creating new member with provider: {}, providerId: {}, nickname: {}",
-                provider, userInfo.getId(), uniqueNickname);
+        log.info("Creating new member with provider: {}, providerId: {}, memberId: {}, nickname: {}",
+                provider, userInfo.getId(), memberId, uniqueNickname);
 
         return memberRepository.save(member);
     }


### PR DESCRIPTION
# 🚀 What’s this PR about?
- member_id에 들어가는 UUID 를 앞 8글자로 제한

# 🛠️ What’s been done?
- 기존에 member_id 생성하는 UUID는 36자로 fk, join이 많을 시 BIGINT, AUTO_INCREMENT 조합보다 약 4배정도 느려질 수 있었음
- 이에 BIGINT와 같은 byte 수를 가진 CHAR(8)의 UUID로 member_id 생성

- BIGINT, AUTO_INCREMENT 조합으로 바꾸려 했다가 다시 UUID로 돌아와서 8글자로 제한한 이유
-> Long 타입으로 member_id를 생성한다 하더라도 OAuth2, jwt를 사용하려면 어차피 String으로 변환해야 함
-> Long <-> String 타입 변환 메소드가 너무 많이 쓰임
-> 기존 서비스 로직들도 DB 내에서 쓰이는 Long 타입형 메소드와, OAuht2/jwt에서 쓰이는 String 타입형 메소드 2개가 동시에 존재해야 해서 코드가 불필요하게 중복됨
-> BIGINT, AUTO_INCREMENT 조합과 조회 속도가 비슷하면서도 동시성 이슈가 없다싶이 한 8글자 UUID로 최종 결정

- 8글자 UUID의 장점
-> 동시성: 약 43억가지의 경우의 수
-> 성능: CHAR(8) = 8바이트 (BIGINT와 동일)
-> 단순함: String 그대로 사용, 변환 로직 불필요
-> 호환성: OAuth2, JWT 완벽 호환

# 🧪 Testing Details
- 다른 도메인들 정상작동 확인했습니다!
<img width="1030" height="69" alt="스크린샷 2025-08-28 오후 7 45 39" src="https://github.com/user-attachments/assets/262ff511-b986-4c48-b6ef-d33c30c604de" />
<img width="367" height="335" alt="스크린샷 2025-08-28 오후 7 46 06" src="https://github.com/user-attachments/assets/1afd9080-f35b-45f4-b742-b119f2abadb7" />

# 👀 Checkpoints for Reviewers
- erd에서 member테이블의 id를 CHAR(8)로 변경했습니다!

# 🎯 Related Issues
closes #33 