### PR TITLE
가이드 직무분야 등록 및 조회 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,23 +28,24 @@ dependencies {
     //swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.8'
 
-    // mapstruct
-    implementation 'org.mapstruct:mapstruct:1.5.5.Final'
-    annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.5.Final'
+    //lombok
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+    testCompileOnly 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
 
     // Lombok과 MapStruct 연동
     annotationProcessor 'org.projectlombok:lombok-mapstruct-binding:0.2.0'
+
+    // mapstruct
+    implementation 'org.mapstruct:mapstruct:1.5.5.Final'
+    annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.5.Final'
 
     //jwt
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
-    //lombok
-    compileOnly 'org.projectlombok:lombok'
-    annotationProcessor 'org.projectlombok:lombok'
-    testCompileOnly 'org.projectlombok:lombok'
-    testAnnotationProcessor 'org.projectlombok:lombok'
 
     //others
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/coffeandcommit/crema/domain/globalTag/dto/JobFieldDTO.java
+++ b/src/main/java/coffeandcommit/crema/domain/globalTag/dto/JobFieldDTO.java
@@ -1,0 +1,28 @@
+package coffeandcommit.crema.domain.globalTag.dto;
+
+import coffeandcommit.crema.domain.globalTag.entity.JobField;
+import coffeandcommit.crema.domain.globalTag.enums.JobNameType;
+import coffeandcommit.crema.domain.globalTag.enums.JobType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class JobFieldDTO {
+
+    private Long id;
+    private JobType jobType;
+    private JobNameType jobName;
+
+    public static JobFieldDTO from(JobField jobField) {
+        return JobFieldDTO.builder()
+                .id(jobField.getId())
+                .jobType(jobField.getJobType())
+                .jobName(jobField.getJobName())
+                .build();
+    }
+}

--- a/src/main/java/coffeandcommit/crema/domain/globalTag/repository/JobFieldRepository.java
+++ b/src/main/java/coffeandcommit/crema/domain/globalTag/repository/JobFieldRepository.java
@@ -1,0 +1,13 @@
+package coffeandcommit.crema.domain.globalTag.repository;
+
+import coffeandcommit.crema.domain.globalTag.entity.JobField;
+import coffeandcommit.crema.domain.globalTag.enums.JobType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface JobFieldRepository extends JpaRepository<JobField, Long> {
+    Optional<JobField> findByJobType(JobType jobType);
+}

--- a/src/main/java/coffeandcommit/crema/domain/guide/controller/GuideController.java
+++ b/src/main/java/coffeandcommit/crema/domain/guide/controller/GuideController.java
@@ -1,8 +1,17 @@
 package coffeandcommit.crema.domain.guide.controller;
 
+import coffeandcommit.crema.domain.guide.dto.response.GuideJobFieldResponseDTO;
+import coffeandcommit.crema.domain.guide.entity.Guide;
+import coffeandcommit.crema.domain.guide.service.GuideService;
+import coffeandcommit.crema.global.auth.service.CustomUserDetails;
+import coffeandcommit.crema.global.common.response.Response;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -12,4 +21,24 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @Tag(name = "Guide" , description = "가이드 API")
 public class GuideController {
+
+    private final GuideService guideService;
+
+    @GetMapping("/{guideId}/job-field")
+    public ResponseEntity<Response<GuideJobFieldResponseDTO>> getGuideJobField(
+            @PathVariable Long guideId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+            ) {
+
+        String loginMemberId = userDetails.getMemberId();
+
+        GuideJobFieldResponseDTO result = guideService.getGuideJobField(guideId, loginMemberId);
+
+        Response<GuideJobFieldResponseDTO> response = Response.<GuideJobFieldResponseDTO>builder()
+                .message("가이드 직무분야 조회 성공")
+                .data(result)
+                .build();
+
+        return ResponseEntity.ok(response);
+    }
 }

--- a/src/main/java/coffeandcommit/crema/domain/guide/controller/GuideController.java
+++ b/src/main/java/coffeandcommit/crema/domain/guide/controller/GuideController.java
@@ -1,7 +1,6 @@
 package coffeandcommit.crema.domain.guide.controller;
 
 import coffeandcommit.crema.domain.guide.dto.response.GuideJobFieldResponseDTO;
-import coffeandcommit.crema.domain.guide.entity.Guide;
 import coffeandcommit.crema.domain.guide.service.GuideService;
 import coffeandcommit.crema.global.auth.service.CustomUserDetails;
 import coffeandcommit.crema.global.common.response.Response;

--- a/src/main/java/coffeandcommit/crema/domain/guide/controller/GuideMeController.java
+++ b/src/main/java/coffeandcommit/crema/domain/guide/controller/GuideMeController.java
@@ -1,5 +1,7 @@
 package coffeandcommit.crema.domain.guide.controller;
 
+import coffeandcommit.crema.domain.guide.dto.request.GuideJobFieldRequestDTO;
+import coffeandcommit.crema.domain.guide.dto.response.GuideJobFieldResponseDTO;
 import coffeandcommit.crema.domain.guide.dto.response.GuideProfileResponseDTO;
 import coffeandcommit.crema.domain.guide.service.GuideMeService;
 import coffeandcommit.crema.global.auth.service.CustomUserDetails;
@@ -38,6 +40,24 @@ public class GuideMeController {
 
 
     }
+
+    @Operation(summary = "가이드 직무 분야 등록", description = "가이드의 직무 분야를 등록합니다.")
+    @PostMapping("/job-field")
+    public ResponseEntity<Response<GuideJobFieldResponseDTO>> registerJobField(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody GuideJobFieldRequestDTO guideJobFieldRequestDTO) {
+
+        GuideJobFieldResponseDTO result = guideMeService.registerGuideJobField(userDetails.getMemberId(), guideJobFieldRequestDTO);
+
+        Response<GuideJobFieldResponseDTO> response = Response.<GuideJobFieldResponseDTO>builder()
+                .message("직무 분야 등록 완료")
+                .data(result)
+                .build();
+
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+
+    }
+
 
 
 }

--- a/src/main/java/coffeandcommit/crema/domain/guide/dto/request/GuideJobFieldRequestDTO.java
+++ b/src/main/java/coffeandcommit/crema/domain/guide/dto/request/GuideJobFieldRequestDTO.java
@@ -1,0 +1,16 @@
+package coffeandcommit.crema.domain.guide.dto.request;
+
+import coffeandcommit.crema.domain.globalTag.enums.JobType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class GuideJobFieldRequestDTO {
+
+    private JobType jobType;
+}

--- a/src/main/java/coffeandcommit/crema/domain/guide/dto/response/GuideJobFieldResponseDTO.java
+++ b/src/main/java/coffeandcommit/crema/domain/guide/dto/response/GuideJobFieldResponseDTO.java
@@ -1,8 +1,6 @@
 package coffeandcommit.crema.domain.guide.dto.response;
 
-import coffeandcommit.crema.domain.globalTag.enums.JobNameType;
-import coffeandcommit.crema.domain.globalTag.enums.JobType;
-import coffeandcommit.crema.domain.guide.entity.Guide;
+import coffeandcommit.crema.domain.globalTag.dto.JobFieldDTO;
 import coffeandcommit.crema.domain.guide.entity.GuideJobField;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -16,14 +14,14 @@ import lombok.NoArgsConstructor;
 public class GuideJobFieldResponseDTO {
 
     private Long guideId;
-    private JobType jobType;
-    private JobNameType jobName;
+    private Long guideJobFieldId;
+    private JobFieldDTO jobFieldDTO;
 
-    public static GuideJobFieldResponseDTO from(Guide guide, GuideJobField guideJobField) {
+    public static GuideJobFieldResponseDTO from(GuideJobField guideJobField){
         return GuideJobFieldResponseDTO.builder()
-                .guideId(guide.getId())
-                .jobType(guideJobField.getJobField().getJobType())
-                .jobName(guideJobField.getJobField().getJobName())
+                .guideId(guideJobField.getGuide().getId())
+                .guideJobFieldId(guideJobField.getId())
+                .jobFieldDTO(JobFieldDTO.from(guideJobField.getJobField()))
                 .build();
     }
 

--- a/src/main/java/coffeandcommit/crema/domain/guide/entity/GuideJobField.java
+++ b/src/main/java/coffeandcommit/crema/domain/guide/entity/GuideJobField.java
@@ -41,4 +41,8 @@ public class GuideJobField extends BaseEntity{
     @JoinColumn(name = "job_field_id", nullable = false)
     @OnDelete(action = OnDeleteAction.CASCADE)
     private JobField jobField; // FK, 직무 분야 ID
+
+    public void updateJobField(JobField jobField) {
+        this.jobField = jobField;
+    }
 }

--- a/src/main/java/coffeandcommit/crema/domain/guide/service/GuideMeService.java
+++ b/src/main/java/coffeandcommit/crema/domain/guide/service/GuideMeService.java
@@ -80,10 +80,10 @@ public class GuideMeService {
         }
 
         // 4. GuideJobField 저장
-        guideJobFieldRepository.save(guideJobField);
+        GuideJobField savedGuideJobField = guideJobFieldRepository.save(guideJobField);
 
         // 5. DTO 변환 및 반환
-        return GuideJobFieldResponseDTO.from(guideJobField);
+        return GuideJobFieldResponseDTO.from(savedGuideJobField);
     }
 
 

--- a/src/main/java/coffeandcommit/crema/domain/guide/service/GuideMeService.java
+++ b/src/main/java/coffeandcommit/crema/domain/guide/service/GuideMeService.java
@@ -1,5 +1,8 @@
 package coffeandcommit.crema.domain.guide.service;
 
+import coffeandcommit.crema.domain.globalTag.entity.JobField;
+import coffeandcommit.crema.domain.globalTag.repository.JobFieldRepository;
+import coffeandcommit.crema.domain.guide.dto.request.GuideJobFieldRequestDTO;
 import coffeandcommit.crema.domain.guide.dto.response.GuideJobFieldResponseDTO;
 import coffeandcommit.crema.domain.guide.dto.response.GuideProfileResponseDTO;
 import coffeandcommit.crema.domain.guide.entity.Guide;
@@ -23,6 +26,7 @@ public class GuideMeService {
 
     private final GuideRepository guideRepository;
     private final GuideJobFieldRepository guideJobFieldRepository;
+    private final JobFieldRepository jobFieldRepository;
 
     @Transactional(readOnly = true)
     public GuideProfileResponseDTO getGuideMeProfile(String memberId) {
@@ -37,7 +41,7 @@ public class GuideMeService {
         int workingPeriodYears = calculateWorkingPeriodYears(guide.getWorkingStart(), guide.getWorkingEnd());
 
         // 4. 직무분야 DTO 변환
-        GuideJobFieldResponseDTO guideJobFieldResponseDTO = GuideJobFieldResponseDTO.from(guide, guideJobField);
+        GuideJobFieldResponseDTO guideJobFieldResponseDTO = GuideJobFieldResponseDTO.from(guideJobField);
 
         return GuideProfileResponseDTO.from(guide, workingPeriodYears, guideJobFieldResponseDTO);
 
@@ -50,4 +54,37 @@ public class GuideMeService {
         int years = Period.between(workingStart, endDate).getYears();
         return Math.max(0, years); // 음수 방지
     }
+
+    @Transactional
+    public GuideJobFieldResponseDTO registerGuideJobField(String memberId, GuideJobFieldRequestDTO guideJobFieldRequestDTO) {
+
+        // 1. 가이드 기본 정보 조회
+        Guide guide = guideRepository.findByMember_Id(memberId)
+                .orElseThrow(() -> new BaseException(ErrorStatus.GUIDE_NOT_FOUND));
+
+        // 2. JobField 엔티티 조회
+        JobField jobField = jobFieldRepository.findByJobType(guideJobFieldRequestDTO.getJobType())
+                .orElseThrow(() -> new BaseException(ErrorStatus.INVALID_JOB_FIELD));
+
+        // 3. 기존 GuideJobField 조회
+        GuideJobField guideJobField = guideJobFieldRepository.findByGuide(guide)
+                .orElse(null);
+        if (guideJobField != null) {
+            // 기존 GuideJobField가 존재하면 업데이트
+            guideJobField.updateJobField(jobField);
+        } else {
+            guideJobField = GuideJobField.builder()
+                    .guide(guide)
+                    .jobField(jobField)
+                    .build();
+        }
+
+        // 4. GuideJobField 저장
+        guideJobFieldRepository.save(guideJobField);
+
+        // 5. DTO 변환 및 반환
+        return GuideJobFieldResponseDTO.from(guideJobField);
+    }
+
+
 }

--- a/src/main/java/coffeandcommit/crema/domain/guide/service/GuideService.java
+++ b/src/main/java/coffeandcommit/crema/domain/guide/service/GuideService.java
@@ -1,11 +1,49 @@
 package coffeandcommit.crema.domain.guide.service;
 
+import coffeandcommit.crema.domain.guide.dto.response.GuideJobFieldResponseDTO;
+import coffeandcommit.crema.domain.guide.entity.Guide;
+import coffeandcommit.crema.domain.guide.entity.GuideJobField;
+import coffeandcommit.crema.domain.guide.repository.GuideJobFieldRepository;
+import coffeandcommit.crema.domain.guide.repository.GuideRepository;
+import coffeandcommit.crema.global.common.exception.BaseException;
+import coffeandcommit.crema.global.common.exception.code.ErrorStatus;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class GuideService {
+
+    private final GuideRepository guideRepository;
+    private final GuideJobFieldRepository guideJobFieldRepository;
+
+    @Transactional(readOnly = true)
+    public GuideJobFieldResponseDTO getGuideJobField(Long guideId, String loginMemberId) {
+
+        // 1. 로그인한 사용자가 가이드인지 확인
+        Guide myGuide = guideRepository.findByMember_Id(loginMemberId)
+                .orElseThrow(() -> new BaseException(ErrorStatus.GUIDE_NOT_FOUND));
+
+        // 2. 조회 대상 가이드 조회
+        Guide targetGuide = guideRepository.findById(guideId)
+                .orElseThrow(() -> new BaseException(ErrorStatus.GUIDE_NOT_FOUND));
+
+        // 3. 공개 여부 체크
+        if(!targetGuide.isOpened()){
+            // 비공개 가이드인 경우, 본인 가이드가 아니면 접근 불가
+            if(!myGuide.getId().equals(targetGuide.getId())){
+                throw new BaseException(ErrorStatus.FORBIDDEN);
+            }
+        }
+
+        // 4. 가이드 직무분야 조회
+        GuideJobField guideJobField = guideJobFieldRepository.findByGuide(targetGuide)
+                .orElseThrow(() -> new BaseException(ErrorStatus.GUIDE_JOB_FIELD_NOT_FOUND));
+
+        return GuideJobFieldResponseDTO.from(guideJobField);
+
+    }
 }

--- a/src/main/java/coffeandcommit/crema/global/common/exception/code/ErrorStatus.java
+++ b/src/main/java/coffeandcommit/crema/global/common/exception/code/ErrorStatus.java
@@ -40,8 +40,8 @@ public enum ErrorStatus implements BaseCode {
 
     // Guide Domain
     GUIDE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 가이드를 찾을 수 없습니다."),
-    GUIDE_JOB_FIELD_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 가이드의 직무 분야를 찾을 수 없습니다.");
-
+    GUIDE_JOB_FIELD_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 가이드의 직무 분야를 찾을 수 없습니다."),
+    INVALID_JOB_FIELD(HttpStatus.BAD_REQUEST, "잘못된 직무 분야 요청입니다.");
 
     public static final String PREFIX = "[ERROR]";
 

--- a/src/test/java/coffeandcommit/crema/domain/guide/service/GuideServiceTest.java
+++ b/src/test/java/coffeandcommit/crema/domain/guide/service/GuideServiceTest.java
@@ -1,0 +1,219 @@
+package coffeandcommit.crema.domain.guide.service;
+
+import coffeandcommit.crema.domain.globalTag.entity.JobField;
+import coffeandcommit.crema.domain.globalTag.enums.JobNameType;
+import coffeandcommit.crema.domain.globalTag.enums.JobType;
+import coffeandcommit.crema.domain.guide.dto.response.GuideJobFieldResponseDTO;
+import coffeandcommit.crema.domain.guide.entity.Guide;
+import coffeandcommit.crema.domain.guide.entity.GuideJobField;
+import coffeandcommit.crema.domain.guide.repository.GuideJobFieldRepository;
+import coffeandcommit.crema.domain.guide.repository.GuideRepository;
+import coffeandcommit.crema.domain.member.entity.Member;
+import coffeandcommit.crema.global.common.exception.BaseException;
+import coffeandcommit.crema.global.common.exception.code.ErrorStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class GuideServiceTest {
+
+    @InjectMocks
+    private GuideService guideService;
+
+    @Mock
+    private GuideRepository guideRepository;
+
+    @Mock
+    private GuideJobFieldRepository guideJobFieldRepository;
+
+    private Member member1;
+    private Member member2;
+    private Guide guide1;
+    private Guide guide2;
+    private JobField jobField;
+    private GuideJobField guideJobField;
+
+    @BeforeEach
+    void setUp() {
+        // Create test members
+        member1 = Member.builder()
+                .id("member1")
+                .build();
+
+        member2 = Member.builder()
+                .id("member2")
+                .build();
+
+        // Create test guides
+        guide1 = Guide.builder()
+                .id(1L)
+                .member(member1)
+                .isOpened(true)
+                .title("Guide 1")
+                .isApproved(true)
+                .build();
+
+        guide2 = Guide.builder()
+                .id(2L)
+                .member(member2)
+                .isOpened(false)  // Private guide
+                .title("Guide 2")
+                .isApproved(true)
+                .build();
+
+        // Create test job field
+        jobField = JobField.builder()
+                .id(1L)
+                .jobType(JobType.DEV_ENGINEERING)
+                .jobName(JobNameType.BACKEND)
+                .build();
+
+        // Create test guide job field
+        guideJobField = GuideJobField.builder()
+                .id(1L)
+                .guide(guide1)
+                .jobField(jobField)
+                .build();
+    }
+
+    @Test
+    @DisplayName("가이드 직무 분야 조회 - 성공")
+    void getGuideJobField_Success() {
+        // Arrange
+        when(guideRepository.findByMember_Id("member1")).thenReturn(Optional.of(guide1));
+        when(guideRepository.findById(1L)).thenReturn(Optional.of(guide1));
+        when(guideJobFieldRepository.findByGuide(guide1)).thenReturn(Optional.of(guideJobField));
+
+        // Act
+        GuideJobFieldResponseDTO result = guideService.getGuideJobField(1L, "member1");
+
+        // Assert
+        assertNotNull(result);
+        assertEquals(1L, result.getGuideId());
+        assertEquals(1L, result.getGuideJobFieldId());
+        assertEquals(JobType.DEV_ENGINEERING, result.getJobFieldDTO().getJobType());
+        assertEquals(JobNameType.BACKEND, result.getJobFieldDTO().getJobName());
+
+        // Verify
+        verify(guideRepository).findByMember_Id("member1");
+        verify(guideRepository).findById(1L);
+        verify(guideJobFieldRepository).findByGuide(guide1);
+    }
+
+    @Test
+    @DisplayName("가이드 직무 분야 조회 - 로그인한 사용자의 가이드를 찾을 수 없음")
+    void getGuideJobField_LoggedInGuideNotFound() {
+        // Arrange
+        when(guideRepository.findByMember_Id("nonexistent")).thenReturn(Optional.empty());
+
+        // Act & Assert
+        BaseException exception = assertThrows(BaseException.class, () -> {
+            guideService.getGuideJobField(1L, "nonexistent");
+        });
+        assertEquals(ErrorStatus.GUIDE_NOT_FOUND, exception.getErrorCode());
+
+        // Verify
+        verify(guideRepository).findByMember_Id("nonexistent");
+        verify(guideRepository, never()).findById(anyLong());
+        verify(guideJobFieldRepository, never()).findByGuide(any());
+    }
+
+    @Test
+    @DisplayName("가이드 직무 분야 조회 - 대상 가이드를 찾을 수 없음")
+    void getGuideJobField_TargetGuideNotFound() {
+        // Arrange
+        when(guideRepository.findByMember_Id("member1")).thenReturn(Optional.of(guide1));
+        when(guideRepository.findById(999L)).thenReturn(Optional.empty());
+
+        // Act & Assert
+        BaseException exception = assertThrows(BaseException.class, () -> {
+            guideService.getGuideJobField(999L, "member1");
+        });
+        assertEquals(ErrorStatus.GUIDE_NOT_FOUND, exception.getErrorCode());
+
+        // Verify
+        verify(guideRepository).findByMember_Id("member1");
+        verify(guideRepository).findById(999L);
+        verify(guideJobFieldRepository, never()).findByGuide(any());
+    }
+
+    @Test
+    @DisplayName("가이드 직무 분야 조회 - 비공개 가이드에 대한 접근 금지")
+    void getGuideJobField_ForbiddenAccessToPrivateGuide() {
+        // Arrange
+        when(guideRepository.findByMember_Id("member1")).thenReturn(Optional.of(guide1));
+        when(guideRepository.findById(2L)).thenReturn(Optional.of(guide2));
+
+        // Act & Assert
+        BaseException exception = assertThrows(BaseException.class, () -> {
+            guideService.getGuideJobField(2L, "member1");
+        });
+        assertEquals(ErrorStatus.FORBIDDEN, exception.getErrorCode());
+
+        // Verify
+        verify(guideRepository).findByMember_Id("member1");
+        verify(guideRepository).findById(2L);
+        verify(guideJobFieldRepository, never()).findByGuide(any());
+    }
+
+    @Test
+    @DisplayName("가이드 직무 분야 조회 - 가이드 직무 분야를 찾을 수 없음")
+    void getGuideJobField_GuideJobFieldNotFound() {
+        // Arrange
+        when(guideRepository.findByMember_Id("member1")).thenReturn(Optional.of(guide1));
+        when(guideRepository.findById(1L)).thenReturn(Optional.of(guide1));
+        when(guideJobFieldRepository.findByGuide(guide1)).thenReturn(Optional.empty());
+
+        // Act & Assert
+        BaseException exception = assertThrows(BaseException.class, () -> {
+            guideService.getGuideJobField(1L, "member1");
+        });
+        assertEquals(ErrorStatus.GUIDE_JOB_FIELD_NOT_FOUND, exception.getErrorCode());
+
+        // Verify
+        verify(guideRepository).findByMember_Id("member1");
+        verify(guideRepository).findById(1L);
+        verify(guideJobFieldRepository).findByGuide(guide1);
+    }
+
+    @Test
+    @DisplayName("가이드 직무 분야 조회 - 소유자는 비공개 가이드에 접근 가능")
+    void getGuideJobField_OwnerCanAccessPrivateGuide() {
+        // Arrange
+        GuideJobField privateGuideJobField = GuideJobField.builder()
+                .id(2L)
+                .guide(guide2)
+                .jobField(jobField)
+                .build();
+
+        when(guideRepository.findByMember_Id("member2")).thenReturn(Optional.of(guide2));
+        when(guideRepository.findById(2L)).thenReturn(Optional.of(guide2));
+        when(guideJobFieldRepository.findByGuide(guide2)).thenReturn(Optional.of(privateGuideJobField));
+
+        // Act
+        GuideJobFieldResponseDTO result = guideService.getGuideJobField(2L, "member2");
+
+        // Assert
+        assertNotNull(result);
+        assertEquals(2L, result.getGuideId());
+        assertEquals(2L, result.getGuideJobFieldId());
+        assertEquals(JobType.DEV_ENGINEERING, result.getJobFieldDTO().getJobType());
+        assertEquals(JobNameType.BACKEND, result.getJobFieldDTO().getJobName());
+
+        // Verify
+        verify(guideRepository).findByMember_Id("member2");
+        verify(guideRepository).findById(2L);
+        verify(guideJobFieldRepository).findByGuide(guide2);
+    }
+}

--- a/src/test/java/coffeandcommit/crema/domain/guide/service/GuideServiceTest.java
+++ b/src/test/java/coffeandcommit/crema/domain/guide/service/GuideServiceTest.java
@@ -19,7 +19,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.time.LocalDate;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;


### PR DESCRIPTION
# 🚀 What’s this PR about?

- 가이드 직무분야 등록 및 조회 API 구현

# 🛠️ What’s been done?

- 등록 API (POST /api/guides/me/job-field)
  - 로그인한 가이드의 직무분야를 등록하거나, 기존 값이 있으면 업데이트
  - GuideJobFieldRequestDTO (jobType) 요청 처리
  - GuideJobFieldResponseDTO 반환 (guideId, guideJobFieldId, jobFieldDTO 포함)
- 조회 API (GET /api/guides/{guideId}/job-field)
  - 특정 가이드의 직무분야 조회 기능 추가
  - 비공개(isOpened=false)일 경우 본인만 접근 가능하도록 권한 검증
  - 조회 시 GUIDE_JOB_FIELD_NOT_FOUND 예외 처리
- 예외 코드 추가/정리
  - INVALID_JOB_FIELD: 잘못된 직무분야 Enum 값 요청 시
  - GUIDE_JOB_FIELD_NOT_FOUND: 해당 가이드에 직무분야가 등록되지 않은 경우

# 🧪 Testing Details
- GuideServiceTest (조회 관련)
  - 가이드 직무 분야 조회 성공
  - 비공개 가이드에 대해 타인 접근 시 → 403 FORBIDDEN
  - 비공개 가이드에 대해 본인 접근 시 → 성공
  - 대상 가이드 없음 → GUIDE_NOT_FOUND
  - 로그인한 사용자가 가이드가 아님 → GUIDE_NOT_FOUND
  - 가이드 직무분야 없음 → GUIDE_JOB_FIELD_NOT_FOUND

- GuideMeServiceTest (등록 및 내 프로필 관련)
  - 새로운 직무분야 등록 성공
  - 기존 직무분야 업데이트 성공 (덮어쓰기)
  - 잘못된 Enum 값 등록 시 → INVALID_JOB_FIELD
  - 가이드가 존재하지 않는 경우 → GUIDE_NOT_FOUND

# 👀 Checkpoints for Reviewers


# 📚 References & Resources


# 🎯 Related Issues
close#50 
