### PR TITLE
[fix] dev 서버 OAuth2 로그인 후 리다이렉트 시 401 에러 해결

### DIFF
--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,7 @@
+# 프로덕션 서버환경 전용 설정
+app:
+  oauth2:
+    authorized-redirect-uri: ${FRONTEND_URL}/oauth2/redirect  # 프론트엔드로 리다이렉트
+  cookie:
+    domain: ${COOKIE_DOMAIN:.coffeechat.kro.kr}  # 프로덕션 도메인 설정
+    same-site: ${COOKIE_SAMESITE:None}  # HTTPS 환경에서 None 사용

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -5,3 +5,5 @@ app:
   cookie:
     domain: ${COOKIE_DOMAIN:.coffeechat.kro.kr}  # 프로덕션 도메인 설정
     same-site: ${COOKIE_SAMESITE:None}  # HTTPS 환경에서 None 사용
+    secure: ${COOKIE_SECURE:true}
+    http-only: ${COOKIE_HTTPONLY:true}


### PR DESCRIPTION
# 🚀 What’s this PR about?
- dev 서버에서 oauth2 로그인 후 홈 화면으로 리다이렉트 하려 하면 401 에러 뜨는 것 해결

# 🛠️ What’s been done?
- 문제 원인: dev 서버에서 https://dev-api-coffeechat.kro.kr/oauth2/authorization/kakao, google 로 로그인이 완료되면, 프론트엔드 테스트를 위해 localhost 3000으로 보냈었음 -> cors 위반
- 문제 해결법: 로그인, 로그인 후 리다이렉트를 모두 한 서버 내의 url로 해결하면 됨
- 최종 채택된 해결법: 배포(prod) 서버에만 프론트 개발 내용이 배포되어 있으므로 prod로 로그인, 로그인 후 리다이렉트 url 통일 
-> 이를 위해 application-prod.yml 추가 및 배포용 환경변수 추가

# 🎯 Related Issues
closes #32 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Chores
  * 프로덕션 전용 환경 설정을 추가해 OAuth2 리디렉션 URL, 쿠키 도메인, SameSite=None, secure 및 http-only 값을 기본화하고 환경 변수로 재정의 가능하게 했습니다.
  * 영향: 프로덕션에서 소셜 로그인 리디렉션과 HTTPS 환경의 인증 쿠키 전달이 안정화되어 세션 유지와 인증 흐름이 개선됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->