### PR TITLE
가이드 스케줄 관련 기능 구현

### DIFF
--- a/src/main/java/coffeandcommit/crema/domain/guide/controller/GuideController.java
+++ b/src/main/java/coffeandcommit/crema/domain/guide/controller/GuideController.java
@@ -3,6 +3,7 @@ package coffeandcommit.crema.domain.guide.controller;
 import coffeandcommit.crema.domain.guide.dto.response.GuideChatTopicResponseDTO;
 import coffeandcommit.crema.domain.guide.dto.response.GuideHashTagResponseDTO;
 import coffeandcommit.crema.domain.guide.dto.response.GuideJobFieldResponseDTO;
+import coffeandcommit.crema.domain.guide.dto.response.GuideScheduleResponseDTO;
 import coffeandcommit.crema.domain.guide.service.GuideService;
 import coffeandcommit.crema.global.auth.service.CustomUserDetails;
 import coffeandcommit.crema.global.common.response.Response;
@@ -82,5 +83,24 @@ public class GuideController {
 
         return ResponseEntity.ok(response);
     }
+
+    @Operation(summary = "가이드 스케줄 조회", description = "특정 가이드의 스케줄을 조회합니다. 비공개 가이드인 경우 본인 가이드만 조회할 수 있습니다.")
+    @GetMapping("/{guideId}/schedules")
+    public ResponseEntity<Response<GuideScheduleResponseDTO>> getGuideSchedules(
+            @PathVariable Long guideId,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+        String loginMemberId = (userDetails != null) ? userDetails.getMemberId() : null;
+
+        GuideScheduleResponseDTO result = guideService.getGuideSchedules(guideId, loginMemberId);
+
+        Response<GuideScheduleResponseDTO> response = Response.<GuideScheduleResponseDTO>builder()
+                .message("가이드 스케줄 조회 성공")
+                .data(result)
+                .build();
+
+        return ResponseEntity.ok(response);
+    }
+
 
 }

--- a/src/main/java/coffeandcommit/crema/domain/guide/controller/GuideMeController.java
+++ b/src/main/java/coffeandcommit/crema/domain/guide/controller/GuideMeController.java
@@ -3,10 +3,8 @@ package coffeandcommit.crema.domain.guide.controller;
 import coffeandcommit.crema.domain.guide.dto.request.GuideChatTopicRequestDTO;
 import coffeandcommit.crema.domain.guide.dto.request.GuideHashTagRequestDTO;
 import coffeandcommit.crema.domain.guide.dto.request.GuideJobFieldRequestDTO;
-import coffeandcommit.crema.domain.guide.dto.response.GuideChatTopicResponseDTO;
-import coffeandcommit.crema.domain.guide.dto.response.GuideHashTagResponseDTO;
-import coffeandcommit.crema.domain.guide.dto.response.GuideJobFieldResponseDTO;
-import coffeandcommit.crema.domain.guide.dto.response.GuideProfileResponseDTO;
+import coffeandcommit.crema.domain.guide.dto.request.GuideScheduleRequestDTO;
+import coffeandcommit.crema.domain.guide.dto.response.*;
 import coffeandcommit.crema.domain.guide.service.GuideMeService;
 import coffeandcommit.crema.global.auth.service.CustomUserDetails;
 import coffeandcommit.crema.global.common.exception.BaseException;
@@ -171,6 +169,51 @@ public class GuideMeController {
 
         return ResponseEntity.status(HttpStatus.OK).body(response);
 
+    }
+
+    @Operation(summary = "가이드 스케줄 등록", description = "가이드의 스케줄을 등록합니다.")
+    @PostMapping("/schedules")
+    public ResponseEntity<Response<GuideScheduleResponseDTO>> registerGuideSchedules(
+            @Valid @RequestBody GuideScheduleRequestDTO guideScheduleRequestDTO,
+            @AuthenticationPrincipal CustomUserDetails userDetails){
+
+        if(userDetails == null){
+            throw new BaseException(ErrorStatus.UNAUTHORIZED);
+        }
+
+        String loginMemberId = userDetails.getMemberId();
+
+        GuideScheduleResponseDTO result = guideMeService.registerGuideSchedules(loginMemberId, guideScheduleRequestDTO);
+
+        Response<GuideScheduleResponseDTO> response = Response.<GuideScheduleResponseDTO>builder()
+                .message("가이드 스케줄 등록 완료")
+                .data(result)
+                .build();
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+
+    }
+
+    @Operation(summary = "가이드 스케줄 삭제", description = "가이드의 스케줄을 삭제합니다.")
+    @DeleteMapping("/schedules/{timeSlotId}")
+    public ResponseEntity<Response<GuideScheduleResponseDTO>> deleteGuideSchedule(
+            @PathVariable Long timeSlotId,
+            @AuthenticationPrincipal CustomUserDetails userDetails){
+
+        if(userDetails == null){
+            throw new BaseException(ErrorStatus.UNAUTHORIZED);
+        }
+
+        String loginMemberId = userDetails.getMemberId();
+
+        GuideScheduleResponseDTO result = guideMeService.deleteGuideSchedule(loginMemberId, timeSlotId);
+
+        Response<GuideScheduleResponseDTO> response = Response.<GuideScheduleResponseDTO>builder()
+                .message("가이드 스케줄 삭제 완료")
+                .data(result)
+                .build();
+
+        return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 
 

--- a/src/main/java/coffeandcommit/crema/domain/guide/dto/request/GuideScheduleRequestDTO.java
+++ b/src/main/java/coffeandcommit/crema/domain/guide/dto/request/GuideScheduleRequestDTO.java
@@ -1,0 +1,19 @@
+package coffeandcommit.crema.domain.guide.dto.request;
+
+import jakarta.validation.constraints.NotEmpty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class GuideScheduleRequestDTO {
+
+    @NotEmpty(message = "스케줄은 최소 1개 이상이어야 합니다.")
+    private List<ScheduleRequestDTO> schedules;
+}

--- a/src/main/java/coffeandcommit/crema/domain/guide/dto/request/GuideScheduleRequestDTO.java
+++ b/src/main/java/coffeandcommit/crema/domain/guide/dto/request/GuideScheduleRequestDTO.java
@@ -1,6 +1,8 @@
 package coffeandcommit.crema.domain.guide.dto.request;
 
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -15,5 +17,6 @@ import java.util.List;
 public class GuideScheduleRequestDTO {
 
     @NotEmpty(message = "스케줄은 최소 1개 이상이어야 합니다.")
-    private List<ScheduleRequestDTO> schedules;
+    @Valid
+    private List<@Valid @NotNull ScheduleRequestDTO> schedules;
 }

--- a/src/main/java/coffeandcommit/crema/domain/guide/dto/request/ScheduleRequestDTO.java
+++ b/src/main/java/coffeandcommit/crema/domain/guide/dto/request/ScheduleRequestDTO.java
@@ -1,0 +1,24 @@
+package coffeandcommit.crema.domain.guide.dto.request;
+
+import coffeandcommit.crema.domain.guide.enums.DayType;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ScheduleRequestDTO {
+
+    @NotNull(message = "요일은 필수 값입니다.")
+    private DayType day;
+
+    @NotEmpty(message = "시간 구간은 최소 1개 이상이어야 합니다.")
+    private List<TimeSlotRequestDTO> timeSlots;
+}

--- a/src/main/java/coffeandcommit/crema/domain/guide/dto/request/ScheduleRequestDTO.java
+++ b/src/main/java/coffeandcommit/crema/domain/guide/dto/request/ScheduleRequestDTO.java
@@ -17,7 +17,7 @@ import java.util.List;
 public class ScheduleRequestDTO {
 
     @NotNull(message = "요일은 필수 값입니다.")
-    private DayType day;
+    private DayType dayOfWeek;
 
     @NotEmpty(message = "시간 구간은 최소 1개 이상이어야 합니다.")
     private List<TimeSlotRequestDTO> timeSlots;

--- a/src/main/java/coffeandcommit/crema/domain/guide/dto/request/TimeSlotRequestDTO.java
+++ b/src/main/java/coffeandcommit/crema/domain/guide/dto/request/TimeSlotRequestDTO.java
@@ -1,11 +1,13 @@
 package coffeandcommit.crema.domain.guide.dto.request;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.time.LocalTime;
 
 @Getter
 @AllArgsConstructor
@@ -14,10 +16,10 @@ import lombok.NoArgsConstructor;
 public class TimeSlotRequestDTO {
 
     @NotBlank(message = "시작 시간은 필수 값입니다.")
-    @Pattern(regexp = "^([01]\\d|2[0-3]):[0-5]\\d$", message = "시작 시간은 HH:mm 형식이어야 합니다.")
-    private String startTime; // 시작 시간 (예: "09:00")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm")
+    private LocalTime startTime; // 시작 시간 (예: "09:00")
 
     @NotBlank(message = "종료 시간은 필수 값입니다.")
-    @Pattern(regexp = "^([01]\\d|2[0-3]):[0-5]\\d$", message = "종료 시간은 HH:mm 형식이어야 합니다.")
-    private String endTime;   // 종료 시간 (예: "10:00")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm")
+    private LocalTime endTime;   // 종료 시간 (예: "10:00")
 }

--- a/src/main/java/coffeandcommit/crema/domain/guide/dto/request/TimeSlotRequestDTO.java
+++ b/src/main/java/coffeandcommit/crema/domain/guide/dto/request/TimeSlotRequestDTO.java
@@ -1,7 +1,7 @@
 package coffeandcommit.crema.domain.guide.dto.request;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -15,11 +15,11 @@ import java.time.LocalTime;
 @Builder
 public class TimeSlotRequestDTO {
 
-    @NotBlank(message = "시작 시간은 필수 값입니다.")
+    @NotNull(message = "시작 시간은 필수 값입니다.")
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm")
     private LocalTime startTime; // 시작 시간 (예: "09:00")
 
-    @NotBlank(message = "종료 시간은 필수 값입니다.")
+    @NotNull(message = "종료 시간은 필수 값입니다.")
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm")
     private LocalTime endTime;   // 종료 시간 (예: "10:00")
 }

--- a/src/main/java/coffeandcommit/crema/domain/guide/dto/request/TimeSlotRequestDTO.java
+++ b/src/main/java/coffeandcommit/crema/domain/guide/dto/request/TimeSlotRequestDTO.java
@@ -1,0 +1,23 @@
+package coffeandcommit.crema.domain.guide.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class TimeSlotRequestDTO {
+
+    @NotBlank(message = "시작 시간은 필수 값입니다.")
+    @Pattern(regexp = "^([01]\\d|2[0-3]):[0-5]\\d$", message = "시작 시간은 HH:mm 형식이어야 합니다.")
+    private String startTime; // 시작 시간 (예: "09:00")
+
+    @NotBlank(message = "종료 시간은 필수 값입니다.")
+    @Pattern(regexp = "^([01]\\d|2[0-3]):[0-5]\\d$", message = "종료 시간은 HH:mm 형식이어야 합니다.")
+    private String endTime;   // 종료 시간 (예: "10:00")
+}

--- a/src/main/java/coffeandcommit/crema/domain/guide/dto/response/GuideScheduleResponseDTO.java
+++ b/src/main/java/coffeandcommit/crema/domain/guide/dto/response/GuideScheduleResponseDTO.java
@@ -1,0 +1,30 @@
+package coffeandcommit.crema.domain.guide.dto.response;
+
+import coffeandcommit.crema.domain.guide.entity.Guide;
+import coffeandcommit.crema.domain.guide.entity.GuideSchedule;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class GuideScheduleResponseDTO {
+
+    private Long guideId; // 가이드 ID
+    private List<ScheduleResponseDTO> schedules;
+
+    public static GuideScheduleResponseDTO from(Guide guide, List<GuideSchedule> guideSchedules) {
+        return GuideScheduleResponseDTO.builder()
+                .guideId(guide.getId())
+                .schedules(guideSchedules.stream()
+                        .map(ScheduleResponseDTO::from)
+                        .toList())
+                .build();
+    }
+
+}

--- a/src/main/java/coffeandcommit/crema/domain/guide/dto/response/GuideScheduleResponseDTO.java
+++ b/src/main/java/coffeandcommit/crema/domain/guide/dto/response/GuideScheduleResponseDTO.java
@@ -23,7 +23,7 @@ public class GuideScheduleResponseDTO {
         return GuideScheduleResponseDTO.builder()
                 .guideId(guide.getId())
                 .schedules(guideSchedules.stream()
-                        .sorted(Comparator.comparing(guideSchedule -> guideSchedule.getDay().ordinal()))
+                        .sorted(Comparator.comparing(guideSchedule -> guideSchedule.getDayOfWeek().ordinal()))
                         .map(ScheduleResponseDTO::from)
                         .toList())
                 .build();

--- a/src/main/java/coffeandcommit/crema/domain/guide/dto/response/GuideScheduleResponseDTO.java
+++ b/src/main/java/coffeandcommit/crema/domain/guide/dto/response/GuideScheduleResponseDTO.java
@@ -23,7 +23,7 @@ public class GuideScheduleResponseDTO {
         return GuideScheduleResponseDTO.builder()
                 .guideId(guide.getId())
                 .schedules(guideSchedules.stream()
-                        .sorted(Comparator.comparing(guideSchedule -> guideSchedule.getDayOfWeek().ordinal()))
+                        .sorted(Comparator.comparing(guideSchedule -> guideSchedule.getDayOfWeek().getOrder()))
                         .map(ScheduleResponseDTO::from)
                         .toList())
                 .build();

--- a/src/main/java/coffeandcommit/crema/domain/guide/dto/response/GuideScheduleResponseDTO.java
+++ b/src/main/java/coffeandcommit/crema/domain/guide/dto/response/GuideScheduleResponseDTO.java
@@ -7,6 +7,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.Comparator;
 import java.util.List;
 
 @Getter
@@ -22,6 +23,7 @@ public class GuideScheduleResponseDTO {
         return GuideScheduleResponseDTO.builder()
                 .guideId(guide.getId())
                 .schedules(guideSchedules.stream()
+                        .sorted(Comparator.comparing(guideSchedule -> guideSchedule.getDay().ordinal()))
                         .map(ScheduleResponseDTO::from)
                         .toList())
                 .build();

--- a/src/main/java/coffeandcommit/crema/domain/guide/dto/response/ScheduleResponseDTO.java
+++ b/src/main/java/coffeandcommit/crema/domain/guide/dto/response/ScheduleResponseDTO.java
@@ -1,12 +1,14 @@
 package coffeandcommit.crema.domain.guide.dto.response;
 
 import coffeandcommit.crema.domain.guide.entity.GuideSchedule;
+import coffeandcommit.crema.domain.guide.entity.TimeSlot;
 import coffeandcommit.crema.domain.guide.enums.DayType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.Comparator;
 import java.util.List;
 
 @Getter
@@ -22,6 +24,7 @@ public class ScheduleResponseDTO {
         return ScheduleResponseDTO.builder()
                 .dayOfWeek(guideSchedule.getDayOfWeek())
                 .timeSlots(guideSchedule.getTimeSlots().stream()
+                        .sorted(Comparator.comparing(TimeSlot::getStartTimeOption))
                         .map(TimeSlotResponseDTO::from)
                         .toList())
                 .build();

--- a/src/main/java/coffeandcommit/crema/domain/guide/dto/response/ScheduleResponseDTO.java
+++ b/src/main/java/coffeandcommit/crema/domain/guide/dto/response/ScheduleResponseDTO.java
@@ -1,0 +1,31 @@
+package coffeandcommit.crema.domain.guide.dto.response;
+
+import coffeandcommit.crema.domain.guide.entity.GuideSchedule;
+import coffeandcommit.crema.domain.guide.enums.DayType;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ScheduleResponseDTO {
+
+    private DayType day;
+    private List<TimeSlotResponseDTO> timeSlots;
+
+    public static ScheduleResponseDTO from(GuideSchedule guideSchedule) {
+        return ScheduleResponseDTO.builder()
+                .day(guideSchedule.getDay())
+                .timeSlots(guideSchedule.getTimeSlots().stream()
+                        .map(TimeSlotResponseDTO::from)
+                        .toList())
+                .build();
+    }
+}

--- a/src/main/java/coffeandcommit/crema/domain/guide/dto/response/ScheduleResponseDTO.java
+++ b/src/main/java/coffeandcommit/crema/domain/guide/dto/response/ScheduleResponseDTO.java
@@ -15,12 +15,12 @@ import java.util.List;
 @Builder
 public class ScheduleResponseDTO {
 
-    private DayType day;
+    private DayType dayOfWeek;
     private List<TimeSlotResponseDTO> timeSlots;
 
     public static ScheduleResponseDTO from(GuideSchedule guideSchedule) {
         return ScheduleResponseDTO.builder()
-                .day(guideSchedule.getDay())
+                .dayOfWeek(guideSchedule.getDayOfWeek())
                 .timeSlots(guideSchedule.getTimeSlots().stream()
                         .map(TimeSlotResponseDTO::from)
                         .toList())

--- a/src/main/java/coffeandcommit/crema/domain/guide/dto/response/ScheduleResponseDTO.java
+++ b/src/main/java/coffeandcommit/crema/domain/guide/dto/response/ScheduleResponseDTO.java
@@ -2,8 +2,6 @@ package coffeandcommit.crema.domain.guide.dto.response;
 
 import coffeandcommit.crema.domain.guide.entity.GuideSchedule;
 import coffeandcommit.crema.domain.guide.enums.DayType;
-import jakarta.validation.constraints.NotEmpty;
-import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/coffeandcommit/crema/domain/guide/dto/response/TimeSlotResponseDTO.java
+++ b/src/main/java/coffeandcommit/crema/domain/guide/dto/response/TimeSlotResponseDTO.java
@@ -1,8 +1,6 @@
 package coffeandcommit.crema.domain.guide.dto.response;
 
 import coffeandcommit.crema.domain.guide.entity.TimeSlot;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/coffeandcommit/crema/domain/guide/dto/response/TimeSlotResponseDTO.java
+++ b/src/main/java/coffeandcommit/crema/domain/guide/dto/response/TimeSlotResponseDTO.java
@@ -1,0 +1,28 @@
+package coffeandcommit.crema.domain.guide.dto.response;
+
+import coffeandcommit.crema.domain.guide.entity.TimeSlot;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class TimeSlotResponseDTO {
+
+    private Long id;
+    private String startTime; // 시작 시간 (예: "09:00")
+    private String endTime;   // 종료 시간 (예: "10:00")
+
+    public static TimeSlotResponseDTO from(TimeSlot timeSlot) {
+        return TimeSlotResponseDTO.builder()
+                .id(timeSlot.getId())
+                .startTime(timeSlot.getStartTimeOption().toString())
+                .endTime(timeSlot.getEndTimeOption().toString())
+                .build();
+    }
+}

--- a/src/main/java/coffeandcommit/crema/domain/guide/entity/GuideSchedule.java
+++ b/src/main/java/coffeandcommit/crema/domain/guide/entity/GuideSchedule.java
@@ -47,6 +47,5 @@ public class GuideSchedule extends BaseEntity{
 
     public void removeTimeSlot(TimeSlot slot) {
         timeSlots.remove(slot);
-        slot.setSchedule(null);
     }
 }

--- a/src/main/java/coffeandcommit/crema/domain/guide/entity/GuideSchedule.java
+++ b/src/main/java/coffeandcommit/crema/domain/guide/entity/GuideSchedule.java
@@ -18,7 +18,7 @@ import java.util.List;
     name = "guide_schedule",
     indexes = {
         @Index(name = "idx_guide_schedule__guide", columnList = "guide_id"),
-        @Index(name = "idx_guide_schedule__day", columnList = "day")
+        @Index(name = "idx_guide_schedule__day_of_week", columnList = "day_of_week")
     }
 )
 public class GuideSchedule extends BaseEntity{
@@ -32,11 +32,12 @@ public class GuideSchedule extends BaseEntity{
     private Guide guide; // FK, 가이드 ID
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "day", nullable = false, length = 20)
-    private DayType day;
+    @Column(name = "day_of_week", nullable = false, length = 20)
+    private DayType dayOfWeek;
 
     @OneToMany(mappedBy = "schedule", cascade = CascadeType.ALL, orphanRemoval = true)
     @Builder.Default
+    @OrderBy("startTimeOption ASC")
     private List<TimeSlot> timeSlots = new ArrayList<>();
 
     // 연관관계 메서드

--- a/src/main/java/coffeandcommit/crema/domain/guide/entity/GuideSchedule.java
+++ b/src/main/java/coffeandcommit/crema/domain/guide/entity/GuideSchedule.java
@@ -1,8 +1,12 @@
 package coffeandcommit.crema.domain.guide.entity;
 
+import coffeandcommit.crema.domain.guide.enums.DayType;
 import coffeandcommit.crema.global.common.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
 
 
 @Entity
@@ -12,12 +16,9 @@ import lombok.*;
 @Builder(toBuilder = true)
 @Table(
     name = "guide_schedule",
-    uniqueConstraints = {
-        @UniqueConstraint(columnNames = {"guide_id", "time_id"})
-    },
     indexes = {
-        @Index(name = "idx_guide_schedule_guide", columnList = "guide_id"),
-        @Index(name = "idx_guide_schedule_time", columnList = "time_id")
+        @Index(name = "idx_guide_schedule__guide", columnList = "guide_id"),
+        @Index(name = "idx_guide_schedule__day", columnList = "day")
     }
 )
 public class GuideSchedule extends BaseEntity{
@@ -30,7 +31,21 @@ public class GuideSchedule extends BaseEntity{
     @JoinColumn(name = "guide_id", nullable = false)
     private Guide guide; // FK, 가이드 ID
 
-    @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "time_id", nullable = false)
-    private TimeSlot time; // FK, 시간 ID
+    @Enumerated(EnumType.STRING)
+    @Column(name = "day", nullable = false, length = 20)
+    private DayType day;
+
+    @OneToMany(mappedBy = "schedule", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<TimeSlot> timeSlots = new ArrayList<>();
+
+    // 연관관계 메서드
+    public void addTimeSlot(TimeSlot slot) {
+        timeSlots.add(slot);
+        slot.setSchedule(this);
+    }
+
+    public void removeTimeSlot(TimeSlot slot) {
+        timeSlots.remove(slot);
+        slot.setSchedule(null);
+    }
 }

--- a/src/main/java/coffeandcommit/crema/domain/guide/entity/GuideSchedule.java
+++ b/src/main/java/coffeandcommit/crema/domain/guide/entity/GuideSchedule.java
@@ -36,6 +36,7 @@ public class GuideSchedule extends BaseEntity{
     private DayType day;
 
     @OneToMany(mappedBy = "schedule", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
     private List<TimeSlot> timeSlots = new ArrayList<>();
 
     // 연관관계 메서드

--- a/src/main/java/coffeandcommit/crema/domain/guide/entity/TimeSlot.java
+++ b/src/main/java/coffeandcommit/crema/domain/guide/entity/TimeSlot.java
@@ -15,13 +15,13 @@ import java.time.LocalTime;
 @Table(
     name = "time_slot",
     uniqueConstraints = {
-        @UniqueConstraint(
-            name = "uk_time_slot__day_start_end",
-            columnNames = {"day", "start_time_option", "end_time_option"}
+            @UniqueConstraint(
+                name = "uk_time_slot__schedule_start_end",
+                columnNames = {"schedule_id", "start_time_option", "end_time_option"}
         )
     },
     indexes = {
-        @Index(name = "idx_time_slot__day", columnList = "day")
+        @Index(name = "idx_time_slot__schedule", columnList = "schedule_id")
     }
 )
 public class TimeSlot extends BaseEntity{
@@ -30,13 +30,18 @@ public class TimeSlot extends BaseEntity{
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "schedule_id", nullable = false)
+    private GuideSchedule schedule; // FK, 가이드 스케줄 ID
+
     @Column(name = "start_time_option", nullable = false)
     private LocalTime startTimeOption; // 시작 시간
 
     @Column(name = "end_time_option", nullable = false)
     private LocalTime endTimeOption; // 종료 시간
 
-    @Enumerated(EnumType.STRING)
-    @Column(name = "day", nullable = false)
-    private DayType day;
+    public void setSchedule(GuideSchedule schedule) {
+        this.schedule = schedule;
+    }
+
 }

--- a/src/main/java/coffeandcommit/crema/domain/guide/entity/TimeSlot.java
+++ b/src/main/java/coffeandcommit/crema/domain/guide/entity/TimeSlot.java
@@ -1,6 +1,5 @@
 package coffeandcommit.crema.domain.guide.entity;
 
-import coffeandcommit.crema.domain.guide.enums.DayType;
 import coffeandcommit.crema.global.common.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;

--- a/src/main/java/coffeandcommit/crema/domain/guide/enums/DayType.java
+++ b/src/main/java/coffeandcommit/crema/domain/guide/enums/DayType.java
@@ -9,11 +9,13 @@ import lombok.ToString;
 @ToString
 public enum DayType {
 
-    MONDAY,
-    TUESDAY,
-    WEDNESDAY,
-    THURSDAY,
-    FRIDAY,
-    SATURDAY,
-    SUNDAY
+    MONDAY(1),
+    TUESDAY(2),
+    WEDNESDAY(3),
+    THURSDAY(4),
+    FRIDAY(5),
+    SATURDAY(6),
+    SUNDAY(7);
+
+    private final int order;
 }

--- a/src/main/java/coffeandcommit/crema/domain/guide/repository/GuideScheduleRepository.java
+++ b/src/main/java/coffeandcommit/crema/domain/guide/repository/GuideScheduleRepository.java
@@ -1,0 +1,13 @@
+package coffeandcommit.crema.domain.guide.repository;
+
+import coffeandcommit.crema.domain.guide.entity.Guide;
+import coffeandcommit.crema.domain.guide.entity.GuideSchedule;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface GuideScheduleRepository extends JpaRepository<GuideSchedule, Long> {
+    List<GuideSchedule> findByGuide(Guide guide);
+}

--- a/src/main/java/coffeandcommit/crema/domain/guide/repository/GuideScheduleRepository.java
+++ b/src/main/java/coffeandcommit/crema/domain/guide/repository/GuideScheduleRepository.java
@@ -2,6 +2,7 @@ package coffeandcommit.crema.domain.guide.repository;
 
 import coffeandcommit.crema.domain.guide.entity.Guide;
 import coffeandcommit.crema.domain.guide.entity.GuideSchedule;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -9,5 +10,6 @@ import java.util.List;
 
 @Repository
 public interface GuideScheduleRepository extends JpaRepository<GuideSchedule, Long> {
+    @EntityGraph(attributePaths = "timeSlots")
     List<GuideSchedule> findByGuide(Guide guide);
 }

--- a/src/main/java/coffeandcommit/crema/domain/guide/repository/TimeSlotRepository.java
+++ b/src/main/java/coffeandcommit/crema/domain/guide/repository/TimeSlotRepository.java
@@ -1,0 +1,9 @@
+package coffeandcommit.crema.domain.guide.repository;
+
+import coffeandcommit.crema.domain.guide.entity.TimeSlot;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TimeSlotRepository extends JpaRepository<TimeSlot, Long> {
+}

--- a/src/main/java/coffeandcommit/crema/domain/guide/service/GuideMeService.java
+++ b/src/main/java/coffeandcommit/crema/domain/guide/service/GuideMeService.java
@@ -232,7 +232,7 @@ public class GuideMeService {
                 .map(scheduleRequestDTO -> {
                         GuideSchedule schedule = GuideSchedule.builder()
                                 .guide(guide)
-                                .day(scheduleRequestDTO.getDay())
+                                .dayOfWeek(scheduleRequestDTO.getDayOfWeek())
                                 .build();
 
                     // TimeSlot 변환 및 연관관계 설정

--- a/src/main/java/coffeandcommit/crema/domain/guide/service/GuideMeService.java
+++ b/src/main/java/coffeandcommit/crema/domain/guide/service/GuideMeService.java
@@ -7,18 +7,10 @@ import coffeandcommit.crema.domain.globalTag.repository.ChatTopicRepository;
 import coffeandcommit.crema.domain.guide.dto.request.GuideChatTopicRequestDTO;
 import coffeandcommit.crema.domain.guide.dto.request.GuideHashTagRequestDTO;
 import coffeandcommit.crema.domain.guide.dto.request.GuideJobFieldRequestDTO;
-import coffeandcommit.crema.domain.guide.dto.response.GuideChatTopicResponseDTO;
-import coffeandcommit.crema.domain.guide.dto.response.GuideHashTagResponseDTO;
-import coffeandcommit.crema.domain.guide.dto.response.GuideJobFieldResponseDTO;
-import coffeandcommit.crema.domain.guide.dto.response.GuideProfileResponseDTO;
-import coffeandcommit.crema.domain.guide.entity.Guide;
-import coffeandcommit.crema.domain.guide.entity.GuideChatTopic;
-import coffeandcommit.crema.domain.guide.entity.GuideJobField;
-import coffeandcommit.crema.domain.guide.entity.HashTag;
-import coffeandcommit.crema.domain.guide.repository.GuideChatTopicRepository;
-import coffeandcommit.crema.domain.guide.repository.GuideJobFieldRepository;
-import coffeandcommit.crema.domain.guide.repository.GuideRepository;
-import coffeandcommit.crema.domain.guide.repository.HashTagRepository;
+import coffeandcommit.crema.domain.guide.dto.request.GuideScheduleRequestDTO;
+import coffeandcommit.crema.domain.guide.dto.response.*;
+import coffeandcommit.crema.domain.guide.entity.*;
+import coffeandcommit.crema.domain.guide.repository.*;
 import coffeandcommit.crema.global.common.exception.BaseException;
 import coffeandcommit.crema.global.common.exception.code.ErrorStatus;
 import jakarta.validation.Valid;
@@ -29,6 +21,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.time.LocalTime;
 import java.time.Period;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -43,6 +36,8 @@ public class GuideMeService {
     private final ChatTopicRepository chatTopicRepository;
     private final GuideChatTopicRepository guideChatTopicRepository;
     private final HashTagRepository hashTagRepository;
+    private final GuideScheduleRepository guideScheduleRepository;
+    private final TimeSlotRepository timeSlotRepository;
 
     /* 가이드 본인 프로필 조회 */
     @Transactional(readOnly = true)
@@ -223,5 +218,79 @@ public class GuideMeService {
         return hashTagRepository.findByGuide(guide).stream()
                 .map(ht -> GuideHashTagResponseDTO.from(ht, guide.getId()))
                 .collect(Collectors.toList());
+    }
+
+    /* 가이드 스케줄 등록 */
+    @Transactional
+    public GuideScheduleResponseDTO registerGuideSchedules(String loginMemberId, @Valid GuideScheduleRequestDTO guideScheduleRequestDTO) {
+
+        Guide guide = guideRepository.findByMember_Id(loginMemberId)
+                .orElseThrow(() -> new BaseException(ErrorStatus.GUIDE_NOT_FOUND));
+
+        // 요청 DTO -> GuideSchedule + TimeSlot 변환
+        List<GuideSchedule> schedules = guideScheduleRequestDTO.getSchedules().stream()
+                .map(scheduleRequestDTO -> {
+                        GuideSchedule schedule = GuideSchedule.builder()
+                                .guide(guide)
+                                .day(scheduleRequestDTO.getDay())
+                                .build();
+
+                    // TimeSlot 변환 및 연관관계 설정
+                    List<TimeSlot> timeSlots = scheduleRequestDTO.getTimeSlots().stream()
+                            .map(timeSlotRequestDTO -> {
+                                    LocalTime start = LocalTime.parse(timeSlotRequestDTO.getStartTime());
+                                    LocalTime end = LocalTime.parse(timeSlotRequestDTO.getEndTime());
+
+                                    if (start.isAfter(end) || start.equals(end)) {
+                                        throw new BaseException(ErrorStatus.INVALID_TIME_RANGE);
+                                    }
+                                    return TimeSlot.builder()
+                                            .schedule(schedule)
+                                            .startTimeOption(start)
+                                            .endTimeOption(end)
+                                            .build();
+                            }).toList();
+
+                    schedule.getTimeSlots().addAll(timeSlots);
+                    return schedule;
+                }).toList();
+
+        List<GuideSchedule> savedSchedules = guideScheduleRepository.saveAll(schedules);
+
+        return GuideScheduleResponseDTO.from(guide, savedSchedules);
+
+    }
+
+    /* 가이드 스케줄 삭제 */
+    public GuideScheduleResponseDTO deleteGuideSchedule(String loginMemberId, Long timeSlotId) {
+
+        // 1. 로그인한 사용자의 Guide 조회
+        Guide guide = guideRepository.findByMember_Id(loginMemberId)
+                .orElseThrow(() -> new BaseException(ErrorStatus.GUIDE_NOT_FOUND));
+
+        // 2. 삭제할 TimeSlot 조회
+        TimeSlot timeSlot = timeSlotRepository.findById(timeSlotId)
+                .orElseThrow(() -> new BaseException(ErrorStatus.TIME_SLOT_NOT_FOUND));
+
+        GuideSchedule schedule = timeSlot.getSchedule();
+
+        // 3. 소유자 검증
+        if (!schedule.getGuide().getId().equals(guide.getId())) {
+            throw new BaseException(ErrorStatus.FORBIDDEN);
+        }
+
+        // 4. 삭제 처리
+        if (schedule.getTimeSlots().size() == 1) {
+            // 시간대가 1개뿐이면 요일 스케줄 자체 삭제
+            guideScheduleRepository.delete(schedule);
+        } else {
+            // 시간대만 삭제
+            timeSlotRepository.delete(timeSlot);
+        }
+
+        // 5. 남은 전체 스케줄 조회 후 응답 변환
+        List<GuideSchedule> remainingSchedules = guideScheduleRepository.findByGuide(guide);
+
+        return GuideScheduleResponseDTO.from(guide, remainingSchedules);
     }
 }

--- a/src/main/java/coffeandcommit/crema/domain/guide/service/GuideService.java
+++ b/src/main/java/coffeandcommit/crema/domain/guide/service/GuideService.java
@@ -34,7 +34,7 @@ public class GuideService {
         if (!targetGuide.isOpened()) {
             // 비공개인데 로그인 안 했거나 본인이 아니면 접근 금지
             if (loginMemberId == null || !Objects.equals(targetGuide.getMember().getId(), loginMemberId)) {
-                throw new BaseException(ErrorStatus.FORBIDDEN);
+                throw new BaseException(ErrorStatus.GUIDE_NOT_FOUND);
             }
         }
     }

--- a/src/main/java/coffeandcommit/crema/domain/guide/service/GuideService.java
+++ b/src/main/java/coffeandcommit/crema/domain/guide/service/GuideService.java
@@ -3,12 +3,11 @@ package coffeandcommit.crema.domain.guide.service;
 import coffeandcommit.crema.domain.guide.dto.response.GuideChatTopicResponseDTO;
 import coffeandcommit.crema.domain.guide.dto.response.GuideHashTagResponseDTO;
 import coffeandcommit.crema.domain.guide.dto.response.GuideJobFieldResponseDTO;
+import coffeandcommit.crema.domain.guide.dto.response.GuideScheduleResponseDTO;
 import coffeandcommit.crema.domain.guide.entity.Guide;
 import coffeandcommit.crema.domain.guide.entity.GuideJobField;
-import coffeandcommit.crema.domain.guide.repository.GuideChatTopicRepository;
-import coffeandcommit.crema.domain.guide.repository.GuideJobFieldRepository;
-import coffeandcommit.crema.domain.guide.repository.GuideRepository;
-import coffeandcommit.crema.domain.guide.repository.HashTagRepository;
+import coffeandcommit.crema.domain.guide.entity.GuideSchedule;
+import coffeandcommit.crema.domain.guide.repository.*;
 import coffeandcommit.crema.global.common.exception.BaseException;
 import coffeandcommit.crema.global.common.exception.code.ErrorStatus;
 import lombok.RequiredArgsConstructor;
@@ -29,6 +28,16 @@ public class GuideService {
     private final GuideJobFieldRepository guideJobFieldRepository;
     private final GuideChatTopicRepository guideChatTopicRepository;
     private final HashTagRepository hashTagRepository;
+    private final GuideScheduleRepository guideScheduleRepository;
+
+    private void validateAccess(Guide targetGuide, String loginMemberId) {
+        if (!targetGuide.isOpened()) {
+            // 비공개인데 로그인 안 했거나 본인이 아니면 접근 금지
+            if (loginMemberId == null || !Objects.equals(targetGuide.getMember().getId(), loginMemberId)) {
+                throw new BaseException(ErrorStatus.FORBIDDEN);
+            }
+        }
+    }
 
     /* 가이드 직무분야 조회 */
     @Transactional(readOnly = true)
@@ -38,23 +47,7 @@ public class GuideService {
         Guide targetGuide = guideRepository.findById(guideId)
                 .orElseThrow(() -> new BaseException(ErrorStatus.GUIDE_NOT_FOUND));
 
-
-        // 2. 공개 여부 체크
-        if (!targetGuide.isOpened()) {
-            // 비공개 가이드일 경우 로그인 필요
-            if (loginMemberId == null) {
-                throw new BaseException(ErrorStatus.FORBIDDEN);
-            }
-
-            // 로그인한 사용자가 가이드인지 확인
-            Guide myGuide = guideRepository.findByMember_Id(loginMemberId)
-                    .orElseThrow(() -> new BaseException(ErrorStatus.GUIDE_NOT_FOUND));
-
-            // 본인 가이드가 아니면 접근 불가
-            if (!Objects.equals(myGuide.getId(), targetGuide.getId())) {
-                throw new BaseException(ErrorStatus.FORBIDDEN);
-            }
-        }
+        validateAccess(targetGuide, loginMemberId);
 
         // 3. 가이드 직무분야 조회
         GuideJobField guideJobField = guideJobFieldRepository.findByGuide(targetGuide)
@@ -72,22 +65,7 @@ public class GuideService {
         Guide targetGuide = guideRepository.findById(guideId)
                 .orElseThrow(() -> new BaseException(ErrorStatus.GUIDE_NOT_FOUND));
 
-
-        if (!targetGuide.isOpened()) {
-            // 비공개 가이드일 경우 로그인 필요
-            if (loginMemberId == null) {
-                throw new BaseException(ErrorStatus.FORBIDDEN);
-            }
-
-            // 로그인한 사용자가 가이드인지 확인
-            Guide myGuide = guideRepository.findByMember_Id(loginMemberId)
-                    .orElseThrow(() -> new BaseException(ErrorStatus.GUIDE_NOT_FOUND));
-
-            // 본인 가이드가 아니면 접근 불가
-            if (!Objects.equals(myGuide.getId(), targetGuide.getId())) {
-                throw new BaseException(ErrorStatus.FORBIDDEN);
-            }
-        }
+        validateAccess(targetGuide, loginMemberId);
 
         // 3. 해당 가이드의 채팅 주제 조회
         return guideChatTopicRepository.findAllByGuideWithJoin(targetGuide).stream()
@@ -103,25 +81,29 @@ public class GuideService {
         Guide targetGuide = guideRepository.findById(guideId)
                 .orElseThrow(() -> new BaseException(ErrorStatus.GUIDE_NOT_FOUND));
 
-        if (!targetGuide.isOpened()) {
-            // 비공개 가이드일 경우 로그인 필요
-            if (loginMemberId == null) {
-                throw new BaseException(ErrorStatus.FORBIDDEN);
-            }
+        validateAccess(targetGuide, loginMemberId);
 
-            // 로그인한 사용자가 가이드인지 확인
-            Guide myGuide = guideRepository.findByMember_Id(loginMemberId)
-                    .orElseThrow(() -> new BaseException(ErrorStatus.GUIDE_NOT_FOUND));
-
-            // 본인 가이드가 아니면 접근 불가
-            if (!Objects.equals(myGuide.getId(), targetGuide.getId())) {
-                throw new BaseException(ErrorStatus.FORBIDDEN);
-            }
-        }
 
         // 3. 해당 가이드의 해시태그 조회
         return hashTagRepository.findByGuide(targetGuide).stream()
                 .map(ht -> GuideHashTagResponseDTO.from(ht, guideId))
                 .collect(Collectors.toList());
+    }
+
+    /* 가이드 스케줄 조회 */
+    @Transactional(readOnly = true)
+    public GuideScheduleResponseDTO getGuideSchedules(Long guideId, String loginMemberId) {
+
+        // 1. 조회 대상 가이드 조회
+        Guide targetGuide = guideRepository.findById(guideId)
+                .orElseThrow(() -> new BaseException(ErrorStatus.GUIDE_NOT_FOUND));
+
+        validateAccess(targetGuide, loginMemberId);
+
+        // 3. 가이드의 스케줄 전체 조회
+        List<GuideSchedule> schedules = guideScheduleRepository.findByGuide(targetGuide);
+
+        // 4. DTO 변환
+        return GuideScheduleResponseDTO.from(targetGuide, schedules);
     }
 }

--- a/src/main/java/coffeandcommit/crema/global/common/exception/code/ErrorStatus.java
+++ b/src/main/java/coffeandcommit/crema/global/common/exception/code/ErrorStatus.java
@@ -48,8 +48,10 @@ public enum ErrorStatus implements BaseCode {
     MAX_HASHTAG_EXCEEDED(HttpStatus.UNPROCESSABLE_ENTITY, "해시태그는 최대 5개까지 등록할 수 있습니다."),
     DUPLICATE_HASHTAG(HttpStatus.CONFLICT, "이미 등록된 해시태그입니다."),
     HASHTAG_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 해시태그를 찾을 수 없습니다."),
-    INVALID_TIME_RANGE(HttpStatus.BAD_REQUEST, "시작 시간이 종료 시간보다 같거나 늦을 수 없습니다."),
-    TIME_SLOT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 시간 구간을 찾을 수 없습니다.");
+    INVALID_TIME_RANGE(HttpStatus.UNPROCESSABLE_ENTITY, "시작 시간이 종료 시간보다 같거나 늦을 수 없습니다."),
+    TIME_SLOT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 시간 구간을 찾을 수 없습니다."),
+    DUPLICATE_TIME_SLOT(HttpStatus.CONFLICT, "해당 요일에 겹치는 시간대가 이미 존재합니다.");
+
 
     public static final String PREFIX = "[ERROR]";
 

--- a/src/main/java/coffeandcommit/crema/global/common/exception/code/ErrorStatus.java
+++ b/src/main/java/coffeandcommit/crema/global/common/exception/code/ErrorStatus.java
@@ -47,7 +47,9 @@ public enum ErrorStatus implements BaseCode {
     GUIDE_CHAT_TOPIC_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 가이드 채팅 주제를 찾을 수 없습니다."),
     MAX_HASHTAG_EXCEEDED(HttpStatus.UNPROCESSABLE_ENTITY, "해시태그는 최대 5개까지 등록할 수 있습니다."),
     DUPLICATE_HASHTAG(HttpStatus.CONFLICT, "이미 등록된 해시태그입니다."),
-    HASHTAG_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 해시태그를 찾을 수 없습니다.");
+    HASHTAG_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 해시태그를 찾을 수 없습니다."),
+    INVALID_TIME_RANGE(HttpStatus.BAD_REQUEST, "시작 시간이 종료 시간보다 같거나 늦을 수 없습니다."),
+    TIME_SLOT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 시간 구간을 찾을 수 없습니다.");
 
     public static final String PREFIX = "[ERROR]";
 

--- a/src/test/java/coffeandcommit/crema/domain/guide/service/GuideMeServiceTest.java
+++ b/src/test/java/coffeandcommit/crema/domain/guide/service/GuideMeServiceTest.java
@@ -137,7 +137,7 @@ public class GuideMeServiceTest {
         guideSchedule = GuideSchedule.builder()
                 .id(1L)
                 .guide(guide)
-                .day(DayType.MONDAY)
+                .dayOfWeek(DayType.MONDAY)
                 .timeSlots(new ArrayList<>())  // Initialize timeSlots list
                 .build();
 
@@ -1019,7 +1019,7 @@ public class GuideMeServiceTest {
         GuideSchedule otherGuideSchedule = GuideSchedule.builder()
                 .id(2L)
                 .guide(otherGuide)
-                .day(DayType.TUESDAY)
+                .dayOfWeek(DayType.TUESDAY)
                 .timeSlots(new ArrayList<>())
                 .build();
 
@@ -1065,7 +1065,7 @@ public class GuideMeServiceTest {
                 .build();
 
         ScheduleRequestDTO scheduleRequestDTO = ScheduleRequestDTO.builder()
-                .day(DayType.MONDAY)
+                .dayOfWeek(DayType.MONDAY)
                 .timeSlots(List.of(timeSlotRequestDTO1, timeSlotRequestDTO2))
                 .build();
 
@@ -1082,7 +1082,7 @@ public class GuideMeServiceTest {
         GuideSchedule savedSchedule = GuideSchedule.builder()
                 .id(2L)
                 .guide(guide)
-                .day(DayType.MONDAY)
+                .dayOfWeek(DayType.MONDAY)
                 .timeSlots(timeSlotList)  // Initialize with the list we created
                 .build();
 
@@ -1113,7 +1113,7 @@ public class GuideMeServiceTest {
         assertNotNull(result);
         assertEquals(guide.getId(), result.getGuideId());
         assertEquals(1, result.getSchedules().size());
-        assertEquals(DayType.MONDAY, result.getSchedules().get(0).getDay());
+        assertEquals(DayType.MONDAY, result.getSchedules().get(0).getDayOfWeek());
         assertEquals(2, result.getSchedules().get(0).getTimeSlots().size());
 
         // 메서드 호출 검증
@@ -1131,7 +1131,7 @@ public class GuideMeServiceTest {
                 .build();
 
         ScheduleRequestDTO scheduleRequestDTO = ScheduleRequestDTO.builder()
-                .day(DayType.MONDAY)
+                .dayOfWeek(DayType.MONDAY)
                 .timeSlots(List.of(timeSlotRequestDTO))
                 .build();
 
@@ -1164,7 +1164,7 @@ public class GuideMeServiceTest {
                 .build();
 
         ScheduleRequestDTO scheduleRequestDTO = ScheduleRequestDTO.builder()
-                .day(DayType.MONDAY)
+                .dayOfWeek(DayType.MONDAY)
                 .timeSlots(List.of(invalidTimeSlotRequestDTO))
                 .build();
 
@@ -1197,7 +1197,7 @@ public class GuideMeServiceTest {
                 .build();
 
         ScheduleRequestDTO scheduleRequestDTO = ScheduleRequestDTO.builder()
-                .day(DayType.MONDAY)
+                .dayOfWeek(DayType.MONDAY)
                 .timeSlots(List.of(sameTimeSlotRequestDTO))
                 .build();
 

--- a/src/test/java/coffeandcommit/crema/domain/guide/service/GuideMeServiceTest.java
+++ b/src/test/java/coffeandcommit/crema/domain/guide/service/GuideMeServiceTest.java
@@ -41,6 +41,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -133,7 +134,6 @@ public class GuideMeServiceTest {
                 .chatTopic(chatTopic1)
                 .build();
 
-        // Create test guide schedule and time slot
         guideSchedule = GuideSchedule.builder()
                 .id(1L)
                 .guide(guide)
@@ -1055,13 +1055,13 @@ public class GuideMeServiceTest {
     void registerGuideSchedules_Success() {
         // 테스트 데이터 준비
         TimeSlotRequestDTO timeSlotRequestDTO1 = TimeSlotRequestDTO.builder()
-                .startTime("09:00")
-                .endTime("10:00")
+                .startTime(LocalTime.of(9, 0))
+                .endTime(LocalTime.of(10, 0))
                 .build();
 
         TimeSlotRequestDTO timeSlotRequestDTO2 = TimeSlotRequestDTO.builder()
-                .startTime("14:00")
-                .endTime("15:00")
+                .startTime(LocalTime.of(14, 0))
+                .endTime(LocalTime.of(15, 0))
                 .build();
 
         ScheduleRequestDTO scheduleRequestDTO = ScheduleRequestDTO.builder()
@@ -1077,7 +1077,6 @@ public class GuideMeServiceTest {
         when(guideRepository.findByMember_Id(memberId)).thenReturn(Optional.of(guide));
 
         // 저장된 스케줄 생성
-        // Create GuideSchedule with initialized timeSlots list
         List<TimeSlot> timeSlotList = new ArrayList<>();
 
         GuideSchedule savedSchedule = GuideSchedule.builder()
@@ -1127,8 +1126,8 @@ public class GuideMeServiceTest {
     void registerGuideSchedules_GuideNotFound() {
         // 테스트 데이터 준비
         TimeSlotRequestDTO timeSlotRequestDTO = TimeSlotRequestDTO.builder()
-                .startTime("09:00")
-                .endTime("10:00")
+                .startTime(LocalTime.of(9, 0))
+                .endTime(LocalTime.of(10, 0))
                 .build();
 
         ScheduleRequestDTO scheduleRequestDTO = ScheduleRequestDTO.builder()
@@ -1160,8 +1159,8 @@ public class GuideMeServiceTest {
     void registerGuideSchedules_InvalidTimeRange() {
         // 테스트 데이터 준비 - 시작 시간이 종료 시간보다 늦은 경우
         TimeSlotRequestDTO invalidTimeSlotRequestDTO = TimeSlotRequestDTO.builder()
-                .startTime("10:00")
-                .endTime("09:00")
+                .startTime(LocalTime.of(10, 0))
+                .endTime(LocalTime.of(9, 0))
                 .build();
 
         ScheduleRequestDTO scheduleRequestDTO = ScheduleRequestDTO.builder()
@@ -1193,8 +1192,8 @@ public class GuideMeServiceTest {
     void registerGuideSchedules_SameStartEndTime() {
         // 테스트 데이터 준비 - 시작 시간과 종료 시간이 같은 경우
         TimeSlotRequestDTO sameTimeSlotRequestDTO = TimeSlotRequestDTO.builder()
-                .startTime("09:00")
-                .endTime("09:00")
+                .startTime(LocalTime.of(9, 0))
+                .endTime(LocalTime.of(9, 0))
                 .build();
 
         ScheduleRequestDTO scheduleRequestDTO = ScheduleRequestDTO.builder()

--- a/src/test/java/coffeandcommit/crema/domain/guide/service/GuideServiceTest.java
+++ b/src/test/java/coffeandcommit/crema/domain/guide/service/GuideServiceTest.java
@@ -210,7 +210,7 @@ public class GuideServiceTest {
         BaseException exception = assertThrows(BaseException.class, () -> {
             guideService.getGuideJobField(2L, "nonexistent");
         });
-        assertEquals(ErrorStatus.FORBIDDEN, exception.getErrorCode());
+        assertEquals(ErrorStatus.GUIDE_NOT_FOUND, exception.getErrorCode());
 
         // Verify
         verify(guideRepository).findById(2L);
@@ -245,7 +245,7 @@ public class GuideServiceTest {
         BaseException exception = assertThrows(BaseException.class, () -> {
             guideService.getGuideJobField(2L, "member1");
         });
-        assertEquals(ErrorStatus.FORBIDDEN, exception.getErrorCode());
+        assertEquals(ErrorStatus.GUIDE_NOT_FOUND, exception.getErrorCode());
 
         // Verify
         verify(guideRepository).findById(2L);
@@ -336,7 +336,7 @@ public class GuideServiceTest {
             guideService.getGuideChatTopics(1L, "nonexistent");
         });
 
-        assertEquals(ErrorStatus.FORBIDDEN, exception.getErrorCode());
+        assertEquals(ErrorStatus.GUIDE_NOT_FOUND, exception.getErrorCode());
 
         // 메서드 호출 검증
         verify(guideRepository).findById(1L);
@@ -373,7 +373,7 @@ public class GuideServiceTest {
             guideService.getGuideChatTopics(2L, "member1");
         });
 
-        assertEquals(ErrorStatus.FORBIDDEN, exception.getErrorCode());
+        assertEquals(ErrorStatus.GUIDE_NOT_FOUND, exception.getErrorCode());
 
         // 메서드 호출 검증
         verify(guideRepository).findById(2L);
@@ -489,7 +489,7 @@ public class GuideServiceTest {
             guideService.getGuideHashTags(2L, "member1");
         });
 
-        assertEquals(ErrorStatus.FORBIDDEN, exception.getErrorCode());
+        assertEquals(ErrorStatus.GUIDE_NOT_FOUND, exception.getErrorCode());
 
         // 메서드 호출 검증
         verify(guideRepository).findById(2L);
@@ -606,7 +606,7 @@ public class GuideServiceTest {
             guideService.getGuideSchedules(2L, "member1");
         });
 
-        assertEquals(ErrorStatus.FORBIDDEN, exception.getErrorCode());
+        assertEquals(ErrorStatus.GUIDE_NOT_FOUND, exception.getErrorCode());
 
         // 메서드 호출 검증
         verify(guideRepository).findById(2L);

--- a/src/test/java/coffeandcommit/crema/domain/guide/service/GuideServiceTest.java
+++ b/src/test/java/coffeandcommit/crema/domain/guide/service/GuideServiceTest.java
@@ -151,14 +151,14 @@ public class GuideServiceTest {
         guideSchedule1 = GuideSchedule.builder()
                 .id(1L)
                 .guide(guide1)
-                .day(DayType.MONDAY)
+                .dayOfWeek(DayType.MONDAY)
                 .timeSlots(new ArrayList<>())
                 .build();
 
         guideSchedule2 = GuideSchedule.builder()
                 .id(2L)
                 .guide(guide1)
-                .day(DayType.WEDNESDAY)
+                .dayOfWeek(DayType.WEDNESDAY)
                 .timeSlots(new ArrayList<>())
                 .build();
 
@@ -560,13 +560,13 @@ public class GuideServiceTest {
         assertEquals(2, result.getSchedules().size());
 
         // 첫 번째 스케줄 검증
-        assertEquals(DayType.MONDAY, result.getSchedules().get(0).getDay());
+        assertEquals(DayType.MONDAY, result.getSchedules().get(0).getDayOfWeek());
         assertEquals(1, result.getSchedules().get(0).getTimeSlots().size());
         assertEquals("09:00", result.getSchedules().get(0).getTimeSlots().get(0).getStartTime());
         assertEquals("10:00", result.getSchedules().get(0).getTimeSlots().get(0).getEndTime());
 
         // 두 번째 스케줄 검증
-        assertEquals(DayType.WEDNESDAY, result.getSchedules().get(1).getDay());
+        assertEquals(DayType.WEDNESDAY, result.getSchedules().get(1).getDayOfWeek());
         assertEquals(1, result.getSchedules().get(1).getTimeSlots().size());
         assertEquals("14:00", result.getSchedules().get(1).getTimeSlots().get(0).getStartTime());
         assertEquals("15:00", result.getSchedules().get(1).getTimeSlots().get(0).getEndTime());
@@ -620,7 +620,7 @@ public class GuideServiceTest {
         GuideSchedule privateGuideSchedule = GuideSchedule.builder()
                 .id(3L)
                 .guide(guide2)
-                .day(DayType.FRIDAY)
+                .dayOfWeek(DayType.FRIDAY)
                 .build();
 
         TimeSlot privateTimeSlot = TimeSlot.builder()
@@ -643,7 +643,7 @@ public class GuideServiceTest {
         assertNotNull(result);
         assertEquals(guide2.getId(), result.getGuideId());
         assertEquals(1, result.getSchedules().size());
-        assertEquals(DayType.FRIDAY, result.getSchedules().get(0).getDay());
+        assertEquals(DayType.FRIDAY, result.getSchedules().get(0).getDayOfWeek());
         assertEquals(1, result.getSchedules().get(0).getTimeSlots().size());
         assertEquals("16:00", result.getSchedules().get(0).getTimeSlots().get(0).getStartTime());
         assertEquals("17:00", result.getSchedules().get(0).getTimeSlots().get(0).getEndTime());


### PR DESCRIPTION
# 🚀 What’s this PR about?
- **가이드 스케줄 등록/삭제/조회 기능 추가**
- 가이드가 요일별 시간대를 등록하고, 삭제 및 조회할 수 있는 기능 구현

---

# 🌸 What’s been done?
- **등록 기능**  
  - `POST /api/guides/me/schedules`  
  - 요일(`DayType`)과 시간대(`startTime`, `endTime`)를 등록할 수 있도록 DTO/엔티티/서비스/컨트롤러 구현
  - 잘못된 시간 범위 검증(`INVALID_TIME_RANGE`) 예외 처리
- **삭제 기능**  
  - `DELETE /api/guides/me/schedules/{timeSlotId}`  
  - 특정 요일의 시간대를 단건 삭제 가능  
  - 해당 요일에 시간대가 하나만 남은 경우, 스케줄 자체 삭제 처리
- **조회 기능**  
  - `GET /api/guides/{guideId}/schedules`  
  - 가이드 공개 여부(`isOpened`)에 따라 접근 제어
  - 비공개일 경우 본인만 접근 가능, 공개일 경우 누구나 조회 가능
- **DTO/응답 구조 통일**  
  - `GuideScheduleRequestDTO`, `TimeSlotRequestDTO` 작성
  - `GuideScheduleResponseDTO`, `ScheduleResponseDTO`, `TimeSlotResponseDTO` 작성
  - `from()` 정적 메서드로 엔티티 → DTO 변환 처리

---

# 🧪 Testing Details
- 단위 테스트 작성 (`GuideServiceTest`, `GuideMeServiceTest`)  
- **주요 검증 케이스**
  - 등록 성공: 여러 요일/시간대 등록 시 정상 저장
  - 등록 실패: 시작 시간이 종료 시간보다 늦은 경우 `INVALID_TIME_RANGE`
  - 삭제 성공: 특정 시간대 삭제 후 남은 스케줄 반환
  - 삭제 시 마지막 시간대일 경우 해당 요일 스케줄도 삭제
  - 조회 성공: 공개 가이드는 누구나 조회 가능
  - 조회 실패: 비공개 가이드 접근 시 `FORBIDDEN`
- 테스트 커버리지: 등록/삭제/조회 기본 시나리오 및 예외 처리 포함

---

# 👀 Checkpoints for Reviewers


# 📚 References & Resources


# 🎯 Related Issues
close#63 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 가이드 스케줄 조회 API 추가: 특정 가이드의 요일·시간대 스케줄 확인 가능.
  - 스케줄 관리 API 추가: 인증된 가이드가 스케줄 등록(POST)·삭제(DELETE) 가능.
  - 요청/응답 DTO 추가: 요일·시간대 기반 입력과 HH:mm 형식 응답 제공.
  - 스케줄·시간대 영속화 및 조회 성능 개선을 위한 저장소 추가.
  - 요일(enum)에 정렬 순서(order) 추가.

- 오류 처리
  - 시간 범위, 중복 시간대, 미존재 시간대에 대한 명확한 에러 응답 추가.

- 테스트
  - 스케줄 등록·삭제·조회 정상 및 예외 경로 단위 테스트 보강.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->