### PR TITLE
fix: OAuth2 로그인 후 리다이렉트 uri 수정

### DIFF
--- a/src/main/java/coffeandcommit/crema/global/auth/config/SecurityConfig.java
+++ b/src/main/java/coffeandcommit/crema/global/auth/config/SecurityConfig.java
@@ -51,8 +51,8 @@ public class SecurityConfig {
                                 "/api/member/check/**",
                                 "/api/test/auth/**",
                                 "/api/debug/**", // 디버그 엔드포인트 추가
-                                "/oauth2/**",
-                                "/login/oauth2/**",
+                                "api/oauth2/**",
+                                "api/login/oauth2/**",
                                 // Swagger UI
                                 "/swagger-ui/**",
                                 "/v3/api-docs/**",
@@ -74,7 +74,6 @@ public class SecurityConfig {
                         .anyRequest().authenticated()
                 )
                 .oauth2Login(oauth2 -> oauth2
-                        // loginPage 제거 - Spring Security가 기본 OAuth2 엔드포인트를 자동으로 처리하도록 함
                         .userInfoEndpoint(userInfo -> userInfo.userService(customOAuth2UserService))
                         .successHandler(oAuth2AuthenticationSuccessHandler)
                         .failureHandler(oAuth2AuthenticationFailureHandler)

--- a/src/main/java/coffeandcommit/crema/global/auth/config/SecurityConfig.java
+++ b/src/main/java/coffeandcommit/crema/global/auth/config/SecurityConfig.java
@@ -51,8 +51,8 @@ public class SecurityConfig {
                                 "/api/member/check/**",
                                 "/api/test/auth/**",
                                 "/api/debug/**", // 디버그 엔드포인트 추가
-                                "api/oauth2/**",
-                                "api/login/oauth2/**",
+                                "/api/oauth2/**",
+                                "/api/login/oauth2/**",
                                 // Swagger UI
                                 "/swagger-ui/**",
                                 "/v3/api-docs/**",

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,7 +1,7 @@
 # dev 서버환경 전용 설정
 app:
   oauth2:
-    authorized-redirect-uri: ${FRONTEND_URL}/login/oauth2/redirect  # 프론트엔드로 리다이렉트
+    authorized-redirect-uri: ${FRONTEND_URL}/oauth2/redirect  # 프론트엔드로 리다이렉트
   cookie:
     domain: ${COOKIE_DOMAIN:.coffeechat.kro.kr}  # .coffeechat.kro.kr로 설정하여 모든 서브도메인에서 쿠키 공유
     same-site: ${COOKIE_SAMESITE:None}  # HTTPS 환경에서 cross-site 요청을 위해 None으로 변경

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,7 +1,7 @@
 # 프로덕션 서버환경 전용 설정
 app:
   oauth2:
-    authorized-redirect-uri: ${FRONTEND_URL}/login/oauth2/redirect  # 프론트엔드로 리다이렉트
+    authorized-redirect-uri: ${FRONTEND_URL}/oauth2/redirect  # 프론트엔드로 리다이렉트
   cookie:
     domain: ${COOKIE_DOMAIN:.coffeechat.kro.kr}  # 프로덕션 도메인 설정
     same-site: ${COOKIE_SAMESITE:None}  # HTTPS 환경에서 None 사용

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -53,7 +53,7 @@ spring:
           google:
             client-id: ${GOOGLE_CLIENT_ID}
             client-secret: ${GOOGLE_CLIENT_SECRET}
-            redirect-uri: "{baseUrl}/login/oauth2/code/google"
+            redirect-uri: "{baseUrl}/api/login/oauth2/code/google"
             scope:
               - profile
           kakao:
@@ -61,7 +61,7 @@ spring:
             client-secret: ${KAKAO_CLIENT_SECRET}
             client-authentication-method: client_secret_post
             authorization-grant-type: authorization_code
-            redirect-uri: "{baseUrl}/login/oauth2/code/kakao"
+            redirect-uri: "{baseUrl}/api/login/oauth2/code/kakao"
             scope:
               - profile_nickname
         provider:


### PR DESCRIPTION
# 🚀 What’s this PR about?
- OAuth2 로그인 후 리다이렉트 uri 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **버그 수정**
  - OAuth2 로그인 리디렉트 경로를 /login/oauth2/redirect에서 /oauth2/redirect로 업데이트했습니다.
  - 외부 인증 제공자(예: Google, Kakao)로 돌아오는 콜백 경로에 API 접두사(/api/)가 추가되어 콜백 처리 경로가 변경되었습니다.
  - OAuth2 관련 퍼블릭 엔드포인트에 API 접두사가 반영되어 엔드포인트 접근 경로가 일관되게 변경됩니다.
  - 보안 관련 쿠키 설정(secure, httpOnly)은 변경 없습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->