### PR TITLE
[fix] auth test 도메인에서 계정 생성 시 guide 테이블도 생성하게 수정

### DIFF
--- a/src/main/java/coffeandcommit/crema/domain/guide/entity/Guide.java
+++ b/src/main/java/coffeandcommit/crema/domain/guide/entity/Guide.java
@@ -7,6 +7,8 @@ import lombok.*;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -56,5 +58,25 @@ public class Guide extends BaseEntity {
 
     @Column(name = "is_current")
     private boolean isCurrent;
+
+
+    // test auth에서 멤버(가이드) 하드 삭제 시, 연관된 가이드 정보도 함께 삭제되도록 설정
+    @OneToOne(mappedBy = "guide", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private GuideJobField guideJobField;
+
+    @OneToMany(mappedBy = "guide", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private List<GuideChatTopic> guideChatTopics = new ArrayList<>();
+
+    @OneToMany(mappedBy = "guide", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private List<HashTag> hashTags = new ArrayList<>();
+
+    @OneToMany(mappedBy = "guide", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private List<GuideSchedule> guideSchedules = new ArrayList<>();
+
+    @OneToMany(mappedBy = "guide", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private List<ExperienceGroup> experienceGroups = new ArrayList<>();
+
+    @OneToOne(mappedBy = "guide", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private ExperienceDetail experienceDetail;
 
 }

--- a/src/main/java/coffeandcommit/crema/domain/guide/entity/GuideJobField.java
+++ b/src/main/java/coffeandcommit/crema/domain/guide/entity/GuideJobField.java
@@ -27,6 +27,7 @@ public class GuideJobField extends BaseEntity{
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
     private Long id;
 
     @OneToOne(fetch = FetchType.LAZY, optional = false)

--- a/src/main/java/coffeandcommit/crema/domain/member/entity/Member.java
+++ b/src/main/java/coffeandcommit/crema/domain/member/entity/Member.java
@@ -60,7 +60,7 @@ public class Member extends BaseEntity {
     @Builder.Default
     private Boolean isDeleted = false;
 
-    @OneToOne(mappedBy = "member", fetch = FetchType.LAZY)
+    @OneToOne(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     private Guide guide;
 
     // 프로필 업데이트 (이메일 추가)

--- a/src/main/java/coffeandcommit/crema/domain/member/repository/MemberRepository.java
+++ b/src/main/java/coffeandcommit/crema/domain/member/repository/MemberRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, String> {
@@ -23,13 +24,7 @@ public interface MemberRepository extends JpaRepository<Member, String> {
     @Query("SELECT CASE WHEN COUNT(m) > 0 THEN true ELSE false END FROM Member m WHERE m.nickname = :nickname AND m.isDeleted = false")
     boolean existsByNicknameAndIsDeletedFalse(@Param("nickname") String nickname);
 
-    // native 쿼리, 테스트 계정 일괄 하드삭제용 (is_deleted 조건 무시용)
-    @Modifying
-    @Transactional
-    @Query(value = """
-    DELETE FROM member 
-    WHERE (nickname LIKE 'rookie_%' OR nickname LIKE 'guide_%')
-    AND provider = 'test'
-    """, nativeQuery = true)
-    int deleteTestAccountsNative();
+    // provider='test'인 Member 조회만 (실제 삭제는 서비스에서 CASCADE 활용)
+    @Query("SELECT m FROM Member m WHERE m.provider = 'test'")
+    List<Member> findTestAccounts();
 }

--- a/src/main/java/coffeandcommit/crema/global/auth/controller/TestAuthController.java
+++ b/src/main/java/coffeandcommit/crema/global/auth/controller/TestAuthController.java
@@ -1,5 +1,10 @@
 package coffeandcommit.crema.global.auth.controller;
 
+import coffeandcommit.crema.domain.globalTag.enums.JobNameType;
+import coffeandcommit.crema.domain.guide.entity.Guide;
+import coffeandcommit.crema.domain.guide.entity.GuideJobField;
+import coffeandcommit.crema.domain.guide.repository.GuideJobFieldRepository;
+import coffeandcommit.crema.domain.guide.repository.GuideRepository;
 import coffeandcommit.crema.domain.member.entity.Member;
 import coffeandcommit.crema.domain.member.enums.MemberRole;
 import coffeandcommit.crema.domain.member.repository.MemberRepository;
@@ -17,7 +22,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Profile;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDate;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -32,6 +39,8 @@ public class TestAuthController {
     private final MemberRepository memberRepository;
     private final JwtTokenProvider jwtTokenProvider;
     private final MemberService memberService;
+    private final GuideRepository guideRepository;
+    private final GuideJobFieldRepository guideJobFieldRepository;
 
     @Operation(summary = "루키 테스트 계정 생성", description = "로컬 개발용 루키 테스트 계정을 생성합니다.")
     @PostMapping("/create-rookie")
@@ -63,7 +72,7 @@ public class TestAuthController {
         return ApiResponse.onSuccess(SuccessStatus.CREATED, response);
     }
 
-    @Operation(summary = "테스트 계정 로그인", description = "생성된 테스트 계정으로 로그인하여 JWT 토큰을 발급받습니다.")
+    @Operation(summary = "테스트 계정 로그인", description = "생성된 테스트 계정으로 로그인하여 JWT 토큰을 발급받습니다. provider가 test인 계정만 가능합니다.")
     @PostMapping("/login")
     public ApiResponse<Map<String, String>> loginTestAccount(
             @Parameter(description = "테스트 계정 닉네임 (예: rookie_12345678, guide_12345678)", required = true)
@@ -72,10 +81,6 @@ public class TestAuthController {
         String nickname = request.get("nickname");
 
         if (nickname == null || nickname.trim().isEmpty()) {
-            throw new BaseException(ErrorStatus.BAD_REQUEST);
-        }
-
-        if (!isTestAccount(nickname)) {
             throw new BaseException(ErrorStatus.BAD_REQUEST);
         }
 
@@ -100,7 +105,14 @@ public class TestAuthController {
     @Operation(summary = "테스트 계정 일괄 삭제", description = "생성된 모든 테스트 계정을 완전 삭제합니다.")
     @DeleteMapping("/cleanup")
     public ApiResponse<Map<String, Object>> cleanupTestAccounts() {
-        int deletedCount = memberRepository.deleteTestAccountsNative();
+        // 테스트 계정 조회
+        List<Member> testAccounts = memberRepository.findTestAccounts();
+        int deletedCount = testAccounts.size();
+
+        // JPA의 cascade 기능을 활용하여 연관된 Guide 엔티티도 함께 삭제
+        // Member 엔티티의 @OneToOne(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+        // 설정에 의해 Guide도 자동으로 삭제됨
+        memberRepository.deleteAll(testAccounts);
 
         log.info("테스트 계정 완전 삭제 완료: {}개", deletedCount);
 
@@ -111,6 +123,60 @@ public class TestAuthController {
         return ApiResponse.onSuccess(SuccessStatus.OK, response);
     }
 
+    /**
+     * 테스트 계정 생성 (GUIDE 역할이면 Guide 엔티티도 함께 생성)
+     */
+    private Member createTestMember(String nickname, MemberRole role) {
+        // saveWithRetry를 사용하여 저장 시점 ID 충돌 처리
+        Member member = memberService.saveWithRetry(() ->
+                Member.builder()
+                        .id(memberService.generateId()) // 매번 새로운 ID 생성
+                        .nickname(nickname)
+                        .role(role)
+                        .point(0)
+                        .provider("test")
+                        .providerId(nickname)
+                        .build()
+        );
+
+        // GUIDE 역할이면 Guide 엔티티도 생성 (승격 완료 상태 시뮬레이션)
+        if (role == MemberRole.GUIDE) {
+            createTestGuideEntity(member);
+        }
+
+        return member;
+    }
+
+    /**
+     * 테스트용 Guide 엔티티 생성
+     */
+    private void createTestGuideEntity(Member member) {
+        Guide guide = Guide.builder()
+                .member(member)
+                .isApproved(true)      // 테스트용이므로 승인됨으로 설정
+                .isOpened(true)        // 테스트용이므로 공개로 설정
+                .title("테스트 가이드")
+                .companyName("테스트 회사")
+                .jobPosition("테스트 직책")
+                .workingStart(LocalDate.now().minusYears(2))
+                .workingEnd(null)      // 현재 재직중
+                .isCurrent(true)
+                .build();
+
+        Guide savedGuide = guideRepository.save(guide);
+
+        // 2. GuideJobField도 함께 생성 (필수)
+        GuideJobField guideJobField = GuideJobField.builder()
+                .guide(savedGuide)
+                .jobName(JobNameType.IT_DEVELOPMENT_DATA) // 테스트용 기본값
+                .build();
+
+        guideJobFieldRepository.save(guideJobField);
+    }
+
+    /**
+     * 고유한 닉네임 생성
+     */
     private String generateNickname(String rolePrefix) {
         for (int i = 0; i < 5; i++) {
             String uuid = UUID.randomUUID().toString().substring(0, 8);
@@ -122,24 +188,5 @@ public class TestAuthController {
         }
 
         throw new BaseException(ErrorStatus.INTERNAL_SERVER_ERROR);
-    }
-
-    private Member createTestMember(String nickname, MemberRole role) {
-        // saveWithRetry를 사용하여 저장 시점 ID 충돌 처리
-        return memberService.saveWithRetry(() ->
-                Member.builder()
-                        .id(memberService.generateId()) // 매번 새로운 ID 생성
-                        .nickname(nickname)
-                        .role(role)
-                        .point(0)
-                        .provider("test")
-                        .providerId(nickname)
-                        .build()
-        );
-    }
-
-    private boolean isTestAccount(String nickname) {
-        return nickname != null &&
-                (nickname.startsWith("rookie_") || nickname.startsWith("guide_"));
     }
 }

--- a/src/main/java/coffeandcommit/crema/global/common/config/DatabaseInitializer.java
+++ b/src/main/java/coffeandcommit/crema/global/common/config/DatabaseInitializer.java
@@ -1,0 +1,70 @@
+package coffeandcommit.crema.global.common.config;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.metamodel.EntityType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import jakarta.annotation.PostConstruct;
+
+/**
+ * 애플리케이션 시작 시 모든 JPA 엔티티의 테이블을 생성하는 초기화 컴포넌트
+ *
+ * OAuth2 회원가입 시 Member 테이블만 생성되는 문제를 해결하기 위해
+ * 애플리케이션 시작 시점에 모든 엔티티 클래스를 스캔하여 테이블을 미리 생성합니다.
+ *
+ * 각 엔티티에 대해 COUNT 쿼리를 실행하여 Hibernate가 해당 테이블을 강제로 생성하도록 합니다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DatabaseInitializer {
+
+    private final EntityManager entityManager;
+
+    /**
+     * 애플리케이션 시작 시 모든 엔티티의 테이블을 생성합니다.
+     *
+     * JPA의 Metamodel을 통해 모든 엔티티 클래스를 스캔하고,
+     * 각 엔티티에 대해 COUNT 쿼리를 실행하여 Hibernate가 해당하는 테이블들을 자동으로 생성하도록 합니다.
+     */
+    @PostConstruct
+    @Transactional
+    public void initializeTables() {
+        try {
+            log.info("데이터베이스 테이블 초기화 시작...");
+
+            // EntityManagerFactory의 Metamodel을 통해 모든 엔티티 스캔
+            var entities = entityManager.getEntityManagerFactory().getMetamodel().getEntities();
+
+            int tableCount = 0;
+
+            // 각 엔티티에 대해 COUNT 쿼리 실행하여 테이블 생성 강제
+            for (EntityType<?> entityType : entities) {
+                try {
+                    String entityName = entityType.getName();
+                    String jpql = "SELECT COUNT(e) FROM " + entityName + " e";
+
+                    // COUNT 쿼리 실행 - 이 과정에서 Hibernate가 테이블이 없으면 생성함
+                    Long count = entityManager.createQuery(jpql, Long.class).getSingleResult();
+
+                    log.debug("테이블 초기화 완료: {} (현재 데이터 개수: {})", entityName, count);
+                    tableCount++;
+
+                } catch (Exception e) {
+                    // 개별 엔티티 초기화 실패 시에도 다른 엔티티는 계속 처리
+                    log.warn("엔티티 {} 테이블 초기화 실패: {}", entityType.getName(), e.getMessage());
+                }
+            }
+
+            log.info("데이터베이스 테이블 초기화 완료: 총 {}개 엔티티 처리", tableCount);
+
+        } catch (Exception e) {
+            log.error("데이터베이스 초기화 실패: {}", e.getMessage(), e);
+            // 예외를 다시 던져서 애플리케이션 시작을 중단시킴
+            throw new RuntimeException("데이터베이스 초기화에 실패했습니다.", e);
+        }
+    }
+}

--- a/src/main/java/coffeandcommit/crema/global/common/exception/code/ErrorStatus.java
+++ b/src/main/java/coffeandcommit/crema/global/common/exception/code/ErrorStatus.java
@@ -32,6 +32,10 @@ public enum ErrorStatus implements BaseCode {
     OAUTH2_AUTHENTICATION_FAILED(HttpStatus.UNAUTHORIZED, "OAuth2 인증에 실패했습니다."),
     UNSUPPORTED_OAUTH2_PROVIDER(HttpStatus.BAD_REQUEST, "지원하지 않는 OAuth2 제공자입니다."),
 
+    // Database Initialization - 테이블 초기화 관련
+    TABLE_DATA_NOT_INITIALIZED(HttpStatus.PRECONDITION_FAILED, "테이블에 기본 데이터가 설정되지 않았습니다."),
+    REFERENCE_DATA_MISSING(HttpStatus.PRECONDITION_FAILED, "필요한 기준 데이터가 누락되었습니다."),
+
     // File Upload - 프로필 이미지 전용 에러 추가
     FILE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "파일 업로드에 실패했습니다."),
     INVALID_FILE_FORMAT(HttpStatus.BAD_REQUEST, "유효하지 않은 이미지 파일입니다. 실제 JPG, JPEG, PNG 파일만 업로드 가능합니다."),


### PR DESCRIPTION
# 🚀 What’s this PR about?
- auth test 도메인에서 계정 생성 시 guide 테이블도 생성하게 수정

# 🛠️ What’s been done?
- DatabaseInitializer 구현: 애플리케이션 시작 시 모든 엔티티 테이블 강제 생성
- 테스트 계정 삭제 로직 수정: 외래키 제약조건 위반 문제 해결
- Member-Guide CASCADE 설정 활용으로 안전한 데이터 삭제 구현
- GuideJobField: 명시적 컬럼 매핑 추가
- MemberRepository: 직접 DELETE 대신 JPA CASCADE 방식으로 변경

# 🧪 Testing Details
- 가이드 도메인 api 테스트 및 기타 api 테스트 작동 확인 완료
<img width="2144" height="2334" alt="스크린샷 2025-09-03 오후 3 56 56" src="https://github.com/user-attachments/assets/c284f740-e23a-4709-b779-98ab43a8b50b" />
<img width="2144" height="2334" alt="스크린샷 2025-09-03 오후 3 56 59" src="https://github.com/user-attachments/assets/6934362e-c699-48b0-a3ac-5dd4f708bff0" />

# 👀 Checkpoints for Reviewers
- 추후 enum 타입이 들어간 API aut test로 테스트 시 local MySQL에 enum 데이터 수동 삽입 필요
- ChatTopic 관련 API는 chat_topic 테이블에 기본 데이터가 있어야 동작함 (추후 윤영님이 chat topic 관련된 로직 일괄 삭제해주실 예정)

# 🎯 Related Issues
closes #54 
