### PR TITLE
Feature/#75 review post

### DIFF
--- a/src/main/java/coffeandcommit/crema/domain/reservation/repository/ReservationRepository.java
+++ b/src/main/java/coffeandcommit/crema/domain/reservation/repository/ReservationRepository.java
@@ -1,0 +1,9 @@
+package coffeandcommit.crema.domain.reservation.repository;
+
+import coffeandcommit.crema.domain.reservation.entity.Reservation;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ReservationRepository extends JpaRepository<Reservation, Long> {
+}

--- a/src/main/java/coffeandcommit/crema/domain/reservation/service/ReservationService.java
+++ b/src/main/java/coffeandcommit/crema/domain/reservation/service/ReservationService.java
@@ -16,8 +16,11 @@ public class ReservationService {
 
     private final ReservationRepository reservationRepository;
 
-    public Reservation getReservationOrThrow(@NotNull Long reservationId) {
-
+    /* 예약 존재 여부 확인 */
+    public Reservation getReservationOrThrow(Long reservationId) {
+        if (reservationId == null) {
+            throw new NullPointerException("reservationId must not be null");
+        }
         return reservationRepository.findById(reservationId)
                 .orElseThrow(() -> new BaseException(ErrorStatus.RESERVATION_NOT_FOUND));
     }

--- a/src/main/java/coffeandcommit/crema/domain/reservation/service/ReservationService.java
+++ b/src/main/java/coffeandcommit/crema/domain/reservation/service/ReservationService.java
@@ -20,7 +20,7 @@ public class ReservationService {
     @Transactional(readOnly = true)
     public Reservation getReservationOrThrow(Long reservationId) {
         if (reservationId == null) {
-            throw new BaseException(ErrorStatus.BAD_REQUEST);
+            throw new BaseException(ErrorStatus.INVALID_RESERVATION_ID);
         }
         return reservationRepository.findById(reservationId)
                 .orElseThrow(() -> new BaseException(ErrorStatus.RESERVATION_NOT_FOUND));

--- a/src/main/java/coffeandcommit/crema/domain/reservation/service/ReservationService.java
+++ b/src/main/java/coffeandcommit/crema/domain/reservation/service/ReservationService.java
@@ -7,6 +7,7 @@ import coffeandcommit.crema.global.common.exception.code.ErrorStatus;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
@@ -16,9 +17,10 @@ public class ReservationService {
     private final ReservationRepository reservationRepository;
 
     /* 예약 존재 여부 확인 */
+    @Transactional(readOnly = true)
     public Reservation getReservationOrThrow(Long reservationId) {
         if (reservationId == null) {
-            throw new NullPointerException("reservationId must not be null");
+            throw new BaseException(ErrorStatus.BAD_REQUEST);
         }
         return reservationRepository.findById(reservationId)
                 .orElseThrow(() -> new BaseException(ErrorStatus.RESERVATION_NOT_FOUND));

--- a/src/main/java/coffeandcommit/crema/domain/reservation/service/ReservationService.java
+++ b/src/main/java/coffeandcommit/crema/domain/reservation/service/ReservationService.java
@@ -1,0 +1,24 @@
+package coffeandcommit.crema.domain.reservation.service;
+
+import coffeandcommit.crema.domain.reservation.entity.Reservation;
+import coffeandcommit.crema.domain.reservation.repository.ReservationRepository;
+import coffeandcommit.crema.global.common.exception.BaseException;
+import coffeandcommit.crema.global.common.exception.code.ErrorStatus;
+import jakarta.validation.constraints.NotNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ReservationService {
+
+    private final ReservationRepository reservationRepository;
+
+    public Reservation getReservationOrThrow(@NotNull Long reservationId) {
+
+        return reservationRepository.findById(reservationId)
+                .orElseThrow(() -> new BaseException(ErrorStatus.RESERVATION_NOT_FOUND));
+    }
+}

--- a/src/main/java/coffeandcommit/crema/domain/reservation/service/ReservationService.java
+++ b/src/main/java/coffeandcommit/crema/domain/reservation/service/ReservationService.java
@@ -4,7 +4,6 @@ import coffeandcommit.crema.domain.reservation.entity.Reservation;
 import coffeandcommit.crema.domain.reservation.repository.ReservationRepository;
 import coffeandcommit.crema.global.common.exception.BaseException;
 import coffeandcommit.crema.global.common.exception.code.ErrorStatus;
-import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;

--- a/src/main/java/coffeandcommit/crema/domain/review/controller/ReviewController.java
+++ b/src/main/java/coffeandcommit/crema/domain/review/controller/ReviewController.java
@@ -1,0 +1,56 @@
+package coffeandcommit.crema.domain.review.controller;
+
+import coffeandcommit.crema.domain.review.dto.request.ReviewRequestDTO;
+import coffeandcommit.crema.domain.review.dto.response.ReviewResponseDTO;
+import coffeandcommit.crema.domain.review.service.ReviewService;
+import coffeandcommit.crema.global.auth.service.CustomUserDetails;
+import coffeandcommit.crema.global.common.exception.BaseException;
+import coffeandcommit.crema.global.common.exception.code.ErrorStatus;
+import coffeandcommit.crema.global.common.response.Response;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/reviews")
+@RequiredArgsConstructor
+@Tag(name = "Review" , description = "리뷰 API")
+public class ReviewController {
+
+    private final ReviewService reviewService;
+
+    @Operation(summary = "리뷰 등록", description = "리뷰를 등록합니다.")
+    @PostMapping
+    public ResponseEntity<Response<ReviewResponseDTO>> createReview(
+        @AuthenticationPrincipal CustomUserDetails userDetails,
+        @Valid @RequestBody ReviewRequestDTO reviewRequestDTO) {
+
+        if(userDetails == null){
+            throw new BaseException(ErrorStatus.UNAUTHORIZED);
+        }
+
+        String loginMemberId = userDetails.getMemberId();
+
+        ReviewResponseDTO result = reviewService.createReview(loginMemberId, reviewRequestDTO);
+
+        Response<ReviewResponseDTO> response = Response.<ReviewResponseDTO>builder()
+                .message("리뷰 등록 완료")
+                .data(result)
+                .build();
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+
+
+    }
+
+}

--- a/src/main/java/coffeandcommit/crema/domain/review/dto/request/ExperienceEvaluationRequestDTO.java
+++ b/src/main/java/coffeandcommit/crema/domain/review/dto/request/ExperienceEvaluationRequestDTO.java
@@ -16,6 +16,6 @@ public class ExperienceEvaluationRequestDTO {
     private Long experienceGroupId;
 
     @NotNull
-    private Boolean thumbsUp; // 좋아요 여부
+    private Boolean isThumbsUp; // 좋아요 여부
 
 }

--- a/src/main/java/coffeandcommit/crema/domain/review/dto/request/ExperienceEvaluationRequestDTO.java
+++ b/src/main/java/coffeandcommit/crema/domain/review/dto/request/ExperienceEvaluationRequestDTO.java
@@ -1,5 +1,6 @@
 package coffeandcommit.crema.domain.review.dto.request;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -16,6 +17,7 @@ public class ExperienceEvaluationRequestDTO {
     private Long experienceGroupId;
 
     @NotNull
+    @JsonProperty("thumbsUp")
     private Boolean isThumbsUp; // 좋아요 여부
 
 }

--- a/src/main/java/coffeandcommit/crema/domain/review/dto/request/ExperienceEvaluationRequestDTO.java
+++ b/src/main/java/coffeandcommit/crema/domain/review/dto/request/ExperienceEvaluationRequestDTO.java
@@ -1,0 +1,21 @@
+package coffeandcommit.crema.domain.review.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ExperienceEvaluationRequestDTO {
+
+    @NotNull
+    private Long experienceGroupId;
+
+    @NotNull
+    private Boolean thumbsUp; // 좋아요 여부
+
+}

--- a/src/main/java/coffeandcommit/crema/domain/review/dto/request/ReviewRequestDTO.java
+++ b/src/main/java/coffeandcommit/crema/domain/review/dto/request/ReviewRequestDTO.java
@@ -1,0 +1,31 @@
+package coffeandcommit.crema.domain.review.dto.request;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ReviewRequestDTO {
+
+    @NotNull
+    private Long reservationId; // 리뷰 대상 예약 ID
+
+    @DecimalMin(value = "0.0")
+    @DecimalMax(value = "5.0")
+    private float starReview; // 별점 (1~5)
+
+    @NotBlank
+    @Size(min = 10, max = 500)
+    private String comment; // 후기 내용
+
+    @Valid
+    private List<@Valid ExperienceEvaluationRequestDTO> experienceEvaluations;
+}

--- a/src/main/java/coffeandcommit/crema/domain/review/dto/request/ReviewRequestDTO.java
+++ b/src/main/java/coffeandcommit/crema/domain/review/dto/request/ReviewRequestDTO.java
@@ -19,6 +19,8 @@ public class ReviewRequestDTO {
     @NotNull
     private Long reservationId; // 리뷰 대상 예약 ID
 
+    @NotNull
+    @Digits(integer = 1, fraction = 1)
     @DecimalMin(value = "0.0")
     @DecimalMax(value = "5.0")
     private BigDecimal starReview; // 별점 (1~5)
@@ -27,6 +29,16 @@ public class ReviewRequestDTO {
     @Size(min = 10, max = 500)
     private String comment; // 후기 내용
 
+    @NotEmpty(message = "경험 평가는 최소 1개 이상 입력해야 합니다.")
     @Valid
     private List<@Valid ExperienceEvaluationRequestDTO> experienceEvaluations;
+
+    @AssertTrue(message = "starReview must be in 0.5 increments within [0.0, 5.0]")
+    private boolean isValidStarStep() {
+        if (starReview == null) return true; // @NotNull이 처리
+        return starReview
+                .multiply(new BigDecimal("10"))   // 10배
+                .remainder(new BigDecimal("5"))   // 5로 나눈 나머지
+                .compareTo(BigDecimal.ZERO) == 0; // 0이면 0.5 단위
+    }
 }

--- a/src/main/java/coffeandcommit/crema/domain/review/dto/request/ReviewRequestDTO.java
+++ b/src/main/java/coffeandcommit/crema/domain/review/dto/request/ReviewRequestDTO.java
@@ -7,6 +7,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.math.BigDecimal;
 import java.util.List;
 
 @Getter
@@ -20,7 +21,7 @@ public class ReviewRequestDTO {
 
     @DecimalMin(value = "0.0")
     @DecimalMax(value = "5.0")
-    private float starReview; // 별점 (1~5)
+    private BigDecimal starReview; // 별점 (1~5)
 
     @NotBlank
     @Size(min = 10, max = 500)

--- a/src/main/java/coffeandcommit/crema/domain/review/dto/response/ExperienceEvaluationResponseDTO.java
+++ b/src/main/java/coffeandcommit/crema/domain/review/dto/response/ExperienceEvaluationResponseDTO.java
@@ -1,0 +1,26 @@
+package coffeandcommit.crema.domain.review.dto.response;
+
+import coffeandcommit.crema.domain.review.entity.ReviewExperience;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ExperienceEvaluationResponseDTO {
+
+    private Long experienceGroupId;   // 경험 대주제 ID
+    private String experienceTitle;   // 경험 대주제 제목
+    private Boolean thumbsUp;         // 좋아요 여부
+
+    public static ExperienceEvaluationResponseDTO from(ReviewExperience reviewExperience) {
+        return ExperienceEvaluationResponseDTO.builder()
+                .experienceGroupId(reviewExperience.getExperienceGroup().getId())
+                .experienceTitle(reviewExperience.getExperienceGroup().getExperienceTitle())
+                .thumbsUp(reviewExperience.isThumbsUp())
+                .build();
+    }
+}

--- a/src/main/java/coffeandcommit/crema/domain/review/dto/response/ReviewResponseDTO.java
+++ b/src/main/java/coffeandcommit/crema/domain/review/dto/response/ReviewResponseDTO.java
@@ -1,0 +1,41 @@
+package coffeandcommit.crema.domain.review.dto.response;
+
+import coffeandcommit.crema.domain.review.entity.Review;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ReviewResponseDTO {
+
+    private Long reviewId;         // 리뷰 ID
+    private Long reservationId;    // 예약 ID
+    private float starReview;        // 별점
+    private String comment;        // 후기 내용
+    private LocalDateTime createdAt; // 작성 시간
+
+    private List<ExperienceEvaluationResponseDTO> experienceEvaluations; // 경험 평가 리스트
+
+    public static ReviewResponseDTO from(Review review) {
+        return ReviewResponseDTO.builder()
+                .reviewId(review.getId())
+                .reservationId(review.getReservation().getId())
+                .starReview(review.getStarReview().floatValue())
+                .comment(review.getComment())
+                .createdAt(review.getCreatedAt())
+                .experienceEvaluations(
+                        review.getExperienceEvaluations().stream()
+                                .map(ExperienceEvaluationResponseDTO::from)
+                                .collect(Collectors.toList())
+                )
+                .build();
+    }
+}

--- a/src/main/java/coffeandcommit/crema/domain/review/dto/response/ReviewResponseDTO.java
+++ b/src/main/java/coffeandcommit/crema/domain/review/dto/response/ReviewResponseDTO.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -18,7 +19,7 @@ public class ReviewResponseDTO {
 
     private Long reviewId;         // 리뷰 ID
     private Long reservationId;    // 예약 ID
-    private float starReview;        // 별점
+    private BigDecimal starReview;        // 별점
     private String comment;        // 후기 내용
     private LocalDateTime createdAt; // 작성 시간
 
@@ -28,7 +29,7 @@ public class ReviewResponseDTO {
         return ReviewResponseDTO.builder()
                 .reviewId(review.getId())
                 .reservationId(review.getReservation().getId())
-                .starReview(review.getStarReview().floatValue())
+                .starReview(review.getStarReview())
                 .comment(review.getComment())
                 .createdAt(review.getCreatedAt())
                 .experienceEvaluations(

--- a/src/main/java/coffeandcommit/crema/domain/review/entity/Review.java
+++ b/src/main/java/coffeandcommit/crema/domain/review/entity/Review.java
@@ -5,6 +5,10 @@ import coffeandcommit.crema.global.common.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+
 
 @Entity
 @Getter
@@ -22,11 +26,14 @@ public class Review extends BaseEntity{
     @JoinColumn(name = "reservation_id", nullable = false, unique = true)
     private Reservation reservation; // FK, 예약 ID
 
-    @Column(nullable = false)
-    private float starReview; // 평점
+    @Column(name = "star_review", precision = 2, scale = 1, nullable = false)
+    private BigDecimal starReview; // 별점
 
     @Column(length = 500)
-    private String content; // 후기 내용
+    private String comment; // 후기 내용
+
+    @OneToMany(mappedBy = "review", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ReviewExperience> experienceEvaluations = new ArrayList<>();
 
 
 }

--- a/src/main/java/coffeandcommit/crema/domain/review/entity/Review.java
+++ b/src/main/java/coffeandcommit/crema/domain/review/entity/Review.java
@@ -15,7 +15,12 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder(toBuilder = true)
-@Table(name = "review")
+@Table(
+        name = "review",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_review_reservation", columnNames = "reservation_id")
+        }
+)
 public class Review extends BaseEntity{
 
     @Id
@@ -36,5 +41,9 @@ public class Review extends BaseEntity{
     @OneToMany(mappedBy = "review", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ReviewExperience> experienceEvaluations = new ArrayList<>();
 
+    public void addExperienceEvaluation(ReviewExperience experience) {
+        experience.setReview(this);  // FK 세팅
+        this.experienceEvaluations.add(experience);
+    }
 
 }

--- a/src/main/java/coffeandcommit/crema/domain/review/entity/Review.java
+++ b/src/main/java/coffeandcommit/crema/domain/review/entity/Review.java
@@ -32,6 +32,7 @@ public class Review extends BaseEntity{
     @Column(length = 500)
     private String comment; // 후기 내용
 
+    @Builder.Default
     @OneToMany(mappedBy = "review", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ReviewExperience> experienceEvaluations = new ArrayList<>();
 

--- a/src/main/java/coffeandcommit/crema/domain/review/entity/ReviewExperience.java
+++ b/src/main/java/coffeandcommit/crema/domain/review/entity/ReviewExperience.java
@@ -39,4 +39,8 @@ public class ReviewExperience extends BaseEntity {
 
     @Column(name = "thumbs_up", nullable = false)
     private boolean thumbsUp; // 좋아요 여부
+
+    protected void setReview(Review review) {
+        this.review = review;
+    }
 }

--- a/src/main/java/coffeandcommit/crema/domain/review/entity/ReviewExperience.java
+++ b/src/main/java/coffeandcommit/crema/domain/review/entity/ReviewExperience.java
@@ -37,8 +37,8 @@ public class ReviewExperience extends BaseEntity {
     @JoinColumn(name = "experience_group_id", nullable = false)
     private ExperienceGroup experienceGroup; // FK, 경험 대주제 ID
 
-    @Column(name = "thumbs_up", nullable = false)
-    private boolean thumbsUp; // 좋아요 여부
+    @Column(name = "is_thumbs_up", nullable = false)
+    private boolean isThumbsUp = false; // 좋아요 여부
 
     protected void setReview(Review review) {
         this.review = review;

--- a/src/main/java/coffeandcommit/crema/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/coffeandcommit/crema/domain/review/repository/ReviewRepository.java
@@ -3,9 +3,21 @@ package coffeandcommit.crema.domain.review.repository;
 import coffeandcommit.crema.domain.reservation.entity.Reservation;
 import coffeandcommit.crema.domain.review.entity.Review;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 @Repository
 public interface ReviewRepository extends JpaRepository<Review, Long> {
     boolean existsByReservation(Reservation reservation);
+
+    @Query("""
+        select distinct r from Review r
+        left join fetch r.experienceEvaluations re
+        left join fetch re.experienceGroup eg
+        where r.id = :id
+    """)
+    Optional<Review> findByIdWithExperiences(@Param("id") Long id);
 }

--- a/src/main/java/coffeandcommit/crema/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/coffeandcommit/crema/domain/review/repository/ReviewRepository.java
@@ -15,6 +15,7 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
 
     @Query("""
         select distinct r from Review r
+        join fetch r.reservation res
         left join fetch r.experienceEvaluations re
         left join fetch re.experienceGroup eg
         where r.id = :id

--- a/src/main/java/coffeandcommit/crema/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/coffeandcommit/crema/domain/review/repository/ReviewRepository.java
@@ -1,0 +1,11 @@
+package coffeandcommit.crema.domain.review.repository;
+
+import coffeandcommit.crema.domain.reservation.entity.Reservation;
+import coffeandcommit.crema.domain.review.entity.Review;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ReviewRepository extends JpaRepository<Review, Long> {
+    boolean existsByReservation(Reservation reservation);
+}

--- a/src/main/java/coffeandcommit/crema/domain/review/service/ReviewService.java
+++ b/src/main/java/coffeandcommit/crema/domain/review/service/ReviewService.java
@@ -29,6 +29,7 @@ public class ReviewService {
     private final ReviewRepository reviewRepository;
     private final ExperienceGroupRepository experienceGroupRepository;
 
+    /* 리뷰 생성 */
     @Transactional
     public ReviewResponseDTO createReview(String loginMemberId, @Valid ReviewRequestDTO reviewRequestDTO) {
 

--- a/src/main/java/coffeandcommit/crema/domain/review/service/ReviewService.java
+++ b/src/main/java/coffeandcommit/crema/domain/review/service/ReviewService.java
@@ -1,0 +1,77 @@
+package coffeandcommit.crema.domain.review.service;
+
+import coffeandcommit.crema.domain.guide.entity.ExperienceGroup;
+import coffeandcommit.crema.domain.guide.repository.ExperienceGroupRepository;
+import coffeandcommit.crema.domain.reservation.entity.Reservation;
+import coffeandcommit.crema.domain.reservation.service.ReservationService;
+import coffeandcommit.crema.domain.review.dto.request.ReviewRequestDTO;
+import coffeandcommit.crema.domain.review.dto.response.ReviewResponseDTO;
+import coffeandcommit.crema.domain.review.entity.Review;
+import coffeandcommit.crema.domain.review.entity.ReviewExperience;
+import coffeandcommit.crema.domain.review.repository.ReviewRepository;
+import coffeandcommit.crema.global.common.exception.BaseException;
+import coffeandcommit.crema.global.common.exception.code.ErrorStatus;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ReviewService {
+
+    private final ReservationService reservationService;
+    private final ReviewRepository reviewRepository;
+    private final ExperienceGroupRepository experienceGroupRepository;
+
+    @Transactional
+    public ReviewResponseDTO createReview(String loginMemberId, @Valid ReviewRequestDTO reviewRequestDTO) {
+
+        // 1. 예약 조회 (서비스 메서드 활용)
+        Reservation reservation = reservationService.getReservationOrThrow(reviewRequestDTO.getReservationId());
+
+        // 2. 본인 예약 검증
+        if (!reservation.getMember().getId().equals(loginMemberId)) {
+            throw new BaseException(ErrorStatus.FORBIDDEN);
+        }
+
+        // 3. 중복 리뷰 방지
+        if (reviewRepository.existsByReservation(reservation)) {
+            throw new BaseException(ErrorStatus.DUPLICATE_REVIEW);
+        }
+
+        // 4. Review 생성
+        Review review = Review.builder()
+                .reservation(reservation)
+                .starReview(BigDecimal.valueOf(reviewRequestDTO.getStarReview()))
+                .comment(reviewRequestDTO.getComment())
+                .build();
+
+        // 5. 경험 평가 매핑
+        List<ReviewExperience> experiences = reviewRequestDTO.getExperienceEvaluations().stream()
+                .map(e -> {
+                    ExperienceGroup experienceGroup = experienceGroupRepository.findById(e.getExperienceGroupId())
+                            .orElseThrow(() -> new BaseException(ErrorStatus.EXPERIENCE_NOT_FOUND));
+
+                    return ReviewExperience.builder()
+                            .review(review)
+                            .experienceGroup(experienceGroup)
+                            .thumbsUp(e.getThumbsUp())
+                            .build();
+                })
+                .toList();
+
+        review.getExperienceEvaluations().addAll(experiences);
+
+        // 6. 저장
+        Review saved = reviewRepository.save(review);
+
+        // 7. DTO 변환
+        return ReviewResponseDTO.from(saved);
+    }
+}

--- a/src/main/java/coffeandcommit/crema/global/common/exception/code/ErrorStatus.java
+++ b/src/main/java/coffeandcommit/crema/global/common/exception/code/ErrorStatus.java
@@ -63,7 +63,8 @@ public enum ErrorStatus implements BaseCode {
     // Review Domain
     RESERVATION_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 예약을 찾을 수 없습니다."),
     DUPLICATE_REVIEW(HttpStatus.CONFLICT, "이미 해당 예약에 대한 리뷰가 존재합니다."),
-    REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 리뷰를 찾을 수 없습니다.");
+    REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 리뷰를 찾을 수 없습니다."),
+    INVALID_RESERVATION_ID(HttpStatus.BAD_REQUEST, "예약 ID는 null일 수 없습니다.");
 
 
 

--- a/src/main/java/coffeandcommit/crema/global/common/exception/code/ErrorStatus.java
+++ b/src/main/java/coffeandcommit/crema/global/common/exception/code/ErrorStatus.java
@@ -58,7 +58,13 @@ public enum ErrorStatus implements BaseCode {
     EXPERIENCE_DETAIL_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 가이드 경험 소주제를 찾을 수 없습니다."),
     EXPERIENCE_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "경험 대주제는 최대 6개까지만 등록할 수 있습니다."),
     INVALID_GUIDE_CHAT_TOPIC(HttpStatus.BAD_REQUEST, "잘못된 가이드 커피챗 주제 요청입니다."),
-    EXPERIENCE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 가이드 경험 대주제를 찾을 수 없습니다.");
+    EXPERIENCE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 가이드 경험 대주제를 찾을 수 없습니다."),
+
+    // Review Domain
+    RESERVATION_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 예약을 찾을 수 없습니다."),
+    DUPLICATE_REVIEW(HttpStatus.CONFLICT, "이미 해당 예약에 대한 리뷰가 존재합니다."),
+    REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 리뷰를 찾을 수 없습니다.");
+
 
 
     public static final String PREFIX = "[ERROR]";

--- a/src/test/java/coffeandcommit/crema/domain/reservation/service/ReservationServiceTest.java
+++ b/src/test/java/coffeandcommit/crema/domain/reservation/service/ReservationServiceTest.java
@@ -71,10 +71,10 @@ class ReservationServiceTest {
     @DisplayName("getReservationOrThrow - 실패 케이스: reservationId가 null인 경우")
     void getReservationOrThrow_NullReservationId() {
         // When & Then
-        NullPointerException exception = assertThrows(NullPointerException.class, () -> {
+        BaseException exception = assertThrows(BaseException.class, () -> {
             reservationService.getReservationOrThrow(null);
         });
-        assertEquals("reservationId must not be null", exception.getMessage());
-        verify(reservationRepository, never()).findById(any());
+        assertEquals(ErrorStatus.INVALID_RESERVATION_ID, exception.getErrorCode());
+
     }
 }

--- a/src/test/java/coffeandcommit/crema/domain/reservation/service/ReservationServiceTest.java
+++ b/src/test/java/coffeandcommit/crema/domain/reservation/service/ReservationServiceTest.java
@@ -1,0 +1,80 @@
+package coffeandcommit.crema.domain.reservation.service;
+
+import coffeandcommit.crema.domain.reservation.entity.Reservation;
+import coffeandcommit.crema.domain.reservation.repository.ReservationRepository;
+import coffeandcommit.crema.global.common.exception.BaseException;
+import coffeandcommit.crema.global.common.exception.code.ErrorStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ReservationServiceTest {
+
+    @Mock
+    private ReservationRepository reservationRepository;
+
+    @InjectMocks
+    private ReservationService reservationService;
+
+    private Reservation testReservation;
+    private final Long RESERVATION_ID = 1L;
+
+    @BeforeEach
+    void setUp() {
+        // Create a test reservation
+        testReservation = Reservation.builder()
+                .id(RESERVATION_ID)
+                .build();
+    }
+
+    @Test
+    @DisplayName("getReservationOrThrow - 성공 케이스: 예약이 존재하는 경우")
+    void getReservationOrThrow_Success() {
+        // Given
+        when(reservationRepository.findById(RESERVATION_ID)).thenReturn(Optional.of(testReservation));
+
+        // When
+        Reservation result = reservationService.getReservationOrThrow(RESERVATION_ID);
+
+        // Then
+        assertNotNull(result);
+        assertEquals(RESERVATION_ID, result.getId());
+        verify(reservationRepository, times(1)).findById(RESERVATION_ID);
+    }
+
+    @Test
+    @DisplayName("getReservationOrThrow - 실패 케이스: 예약이 존재하지 않는 경우")
+    void getReservationOrThrow_ReservationNotFound() {
+        // Given
+        when(reservationRepository.findById(RESERVATION_ID)).thenReturn(Optional.empty());
+
+        // When & Then
+        BaseException exception = assertThrows(BaseException.class, () -> {
+            reservationService.getReservationOrThrow(RESERVATION_ID);
+        });
+
+        assertEquals(ErrorStatus.RESERVATION_NOT_FOUND, exception.getErrorCode());
+        verify(reservationRepository, times(1)).findById(RESERVATION_ID);
+    }
+
+    @Test
+    @DisplayName("getReservationOrThrow - 실패 케이스: reservationId가 null인 경우")
+    void getReservationOrThrow_NullReservationId() {
+        // When & Then
+        NullPointerException exception = assertThrows(NullPointerException.class, () -> {
+            reservationService.getReservationOrThrow(null);
+        });
+        assertEquals("reservationId must not be null", exception.getMessage());
+        verify(reservationRepository, never()).findById(any());
+    }
+}

--- a/src/test/java/coffeandcommit/crema/domain/review/service/ReviewServiceTest.java
+++ b/src/test/java/coffeandcommit/crema/domain/review/service/ReviewServiceTest.java
@@ -23,7 +23,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.math.BigDecimal;
 import java.util.Collections;
-import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;

--- a/src/test/java/coffeandcommit/crema/domain/review/service/ReviewServiceTest.java
+++ b/src/test/java/coffeandcommit/crema/domain/review/service/ReviewServiceTest.java
@@ -1,0 +1,190 @@
+package coffeandcommit.crema.domain.review.service;
+
+import coffeandcommit.crema.domain.guide.entity.ExperienceGroup;
+import coffeandcommit.crema.domain.guide.repository.ExperienceGroupRepository;
+import coffeandcommit.crema.domain.member.entity.Member;
+import coffeandcommit.crema.domain.reservation.entity.Reservation;
+import coffeandcommit.crema.domain.reservation.service.ReservationService;
+import coffeandcommit.crema.domain.review.dto.request.ExperienceEvaluationRequestDTO;
+import coffeandcommit.crema.domain.review.dto.request.ReviewRequestDTO;
+import coffeandcommit.crema.domain.review.dto.response.ReviewResponseDTO;
+import coffeandcommit.crema.domain.review.entity.Review;
+import coffeandcommit.crema.domain.review.repository.ReviewRepository;
+import coffeandcommit.crema.global.common.exception.BaseException;
+import coffeandcommit.crema.global.common.exception.code.ErrorStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ReviewServiceTest {
+
+    @Mock
+    private ReservationService reservationService;
+
+    @Mock
+    private ReviewRepository reviewRepository;
+
+    @Mock
+    private ExperienceGroupRepository experienceGroupRepository;
+
+    @InjectMocks
+    private ReviewService reviewService;
+
+    private final Long RESERVATION_ID = 1L;
+    private final Long EXPERIENCE_GROUP_ID = 1L;
+    private final String LOGIN_MEMBER_ID = "member123";
+    private final String COMMENT = "This is a test review comment that is at least 10 characters long.";
+    private final float STAR_REVIEW = 4.5f;
+
+    private Member testMember;
+    private Reservation testReservation;
+    private ExperienceGroup testExperienceGroup;
+    private ReviewRequestDTO testReviewRequestDTO;
+    private Review testReview;
+
+    @BeforeEach
+    void setUp() {
+        // Create test member
+        testMember = Member.builder()
+                .id(LOGIN_MEMBER_ID)
+                .build();
+
+        // Create test reservation
+        testReservation = Reservation.builder()
+                .id(RESERVATION_ID)
+                .member(testMember)
+                .build();
+
+        // Create test experience group
+        testExperienceGroup = ExperienceGroup.builder()
+                .id(EXPERIENCE_GROUP_ID)
+                .experienceTitle("Test Experience")
+                .build();
+
+        // Create test review request DTO
+        ExperienceEvaluationRequestDTO evaluationDTO = ExperienceEvaluationRequestDTO.builder()
+                .experienceGroupId(EXPERIENCE_GROUP_ID)
+                .thumbsUp(true)
+                .build();
+
+        testReviewRequestDTO = ReviewRequestDTO.builder()
+                .reservationId(RESERVATION_ID)
+                .starReview(STAR_REVIEW)
+                .comment(COMMENT)
+                .experienceEvaluations(Collections.singletonList(evaluationDTO))
+                .build();
+
+        // Create test review
+        testReview = Review.builder()
+                .id(1L)
+                .reservation(testReservation)
+                .starReview(BigDecimal.valueOf(STAR_REVIEW))
+                .comment(COMMENT)
+                .build();
+    }
+
+    @Test
+    @DisplayName("createReview - 성공 케이스: 리뷰 생성 성공")
+    void createReview_Success() {
+        // Given
+        when(reservationService.getReservationOrThrow(RESERVATION_ID)).thenReturn(testReservation);
+        when(experienceGroupRepository.findById(EXPERIENCE_GROUP_ID)).thenReturn(java.util.Optional.of(testExperienceGroup));
+        when(reviewRepository.existsByReservation(testReservation)).thenReturn(false);
+        when(reviewRepository.save(any(Review.class))).thenReturn(testReview);
+
+        // When
+        ReviewResponseDTO result = reviewService.createReview(LOGIN_MEMBER_ID, testReviewRequestDTO);
+
+        // Then
+        assertNotNull(result);
+        assertEquals(testReview.getId(), result.getReviewId());
+        assertEquals(RESERVATION_ID, result.getReservationId());
+        assertEquals(STAR_REVIEW, result.getStarReview(), 0.001);
+        assertEquals(COMMENT, result.getComment());
+
+        // Verify interactions
+        verify(reservationService, times(1)).getReservationOrThrow(RESERVATION_ID);
+        verify(reviewRepository, times(1)).existsByReservation(testReservation);
+        verify(experienceGroupRepository, times(1)).findById(EXPERIENCE_GROUP_ID);
+        verify(reviewRepository, times(1)).save(any(Review.class));
+
+        // Capture the Review object passed to save method to verify its properties
+        ArgumentCaptor<Review> reviewCaptor = ArgumentCaptor.forClass(Review.class);
+        verify(reviewRepository).save(reviewCaptor.capture());
+        Review capturedReview = reviewCaptor.getValue();
+
+        assertEquals(testReservation, capturedReview.getReservation());
+        assertEquals(BigDecimal.valueOf(STAR_REVIEW), capturedReview.getStarReview());
+        assertEquals(COMMENT, capturedReview.getComment());
+        assertEquals(1, capturedReview.getExperienceEvaluations().size());
+    }
+
+    @Test
+    @DisplayName("createReview - 실패 케이스: 본인 예약이 아닌 경우")
+    void createReview_Forbidden() {
+        // Given
+        String differentMemberId = "differentMember";
+        when(reservationService.getReservationOrThrow(RESERVATION_ID)).thenReturn(testReservation);
+
+        // When & Then
+        BaseException exception = assertThrows(BaseException.class, () -> {
+            reviewService.createReview(differentMemberId, testReviewRequestDTO);
+        });
+
+        assertEquals(ErrorStatus.FORBIDDEN, exception.getErrorCode());
+        verify(reservationService, times(1)).getReservationOrThrow(RESERVATION_ID);
+        verify(reviewRepository, never()).save(any(Review.class));
+    }
+
+    @Test
+    @DisplayName("createReview - 실패 케이스: 이미 리뷰가 존재하는 경우")
+    void createReview_DuplicateReview() {
+        // Given
+        when(reservationService.getReservationOrThrow(RESERVATION_ID)).thenReturn(testReservation);
+        when(reviewRepository.existsByReservation(testReservation)).thenReturn(true);
+
+        // When & Then
+        BaseException exception = assertThrows(BaseException.class, () -> {
+            reviewService.createReview(LOGIN_MEMBER_ID, testReviewRequestDTO);
+        });
+
+        assertEquals(ErrorStatus.DUPLICATE_REVIEW, exception.getErrorCode());
+        verify(reservationService, times(1)).getReservationOrThrow(RESERVATION_ID);
+        verify(reviewRepository, times(1)).existsByReservation(testReservation);
+        verify(reviewRepository, never()).save(any(Review.class));
+    }
+
+    @Test
+    @DisplayName("createReview - 실패 케이스: 경험 그룹을 찾을 수 없는 경우")
+    void createReview_ExperienceNotFound() {
+        // Given
+        when(reservationService.getReservationOrThrow(RESERVATION_ID)).thenReturn(testReservation);
+        when(reviewRepository.existsByReservation(testReservation)).thenReturn(false);
+        when(experienceGroupRepository.findById(EXPERIENCE_GROUP_ID)).thenReturn(java.util.Optional.empty());
+
+        // When & Then
+        BaseException exception = assertThrows(BaseException.class, () -> {
+            reviewService.createReview(LOGIN_MEMBER_ID, testReviewRequestDTO);
+        });
+
+        assertEquals(ErrorStatus.EXPERIENCE_NOT_FOUND, exception.getErrorCode());
+        verify(reservationService, times(1)).getReservationOrThrow(RESERVATION_ID);
+        verify(reviewRepository, times(1)).existsByReservation(testReservation);
+        verify(experienceGroupRepository, times(1)).findById(EXPERIENCE_GROUP_ID);
+        verify(reviewRepository, never()).save(any(Review.class));
+    }
+}


### PR DESCRIPTION
## 🌸 What’s this PR about?
- **작업 내용 요약:**  
  리뷰 등록 기능을 구현했습니다.  
  - `POST /api/reviews` 엔드포인트 추가  
  - 로그인한 사용자가 본인의 예약 건에 대해 리뷰 작성 가능  
  - 별점(0.5 단위 허용), 코멘트, 경험별 따봉 평가 저장  

---

## 🛠 What’s been done?
- **Controller**
  - `ReviewController#createReview` 구현 (`@AuthenticationPrincipal` 기반 인증 검증)  
  - 리뷰 등록 성공 시 `201 CREATED` 와 함께 `ReviewResponseDTO` 반환  

- **Service**
  - `ReviewService#createReview` 구현  
  - 예약 검증 (`ReservationService` 사용, 본인 예약인지 확인)  
  - 중복 리뷰 방지 (`ReviewRepository.existsByReservation`)  
  - `ReviewExperience` 생성 및 매핑  
  - 저장 후 DTO 변환 반환  

- **Entity & Repository**
  - `Review` 엔티티에 `experienceEvaluations` 연관관계 매핑 추가 (`@OneToMany`)  
  - `ReviewExperience` 엔티티로 경험별 평가 관리  
  - `ReviewRepository.existsByReservation` 메서드 추가  

- **DTO**
  - `ReviewRequestDTO`, `ExperienceEvaluationRequestDTO` 생성  
  - `ReviewResponseDTO`, `ExperienceEvaluationResponseDTO` 생성  


---

# 🧪 Testing Details


- **테스트 코드**
  - `ReviewServiceTest` 작성 (성공/실패 케이스 전부 포함)  
    - 성공 케이스: 리뷰 생성 및 저장 확인  
    - 실패 케이스: 본인 예약 아님 → `FORBIDDEN`  
    - 실패 케이스: 중복 리뷰 존재 → `DUPLICATE_REVIEW`  
    - 실패 케이스: 경험 그룹 없음 → `EXPERIENCE_NOT_FOUND`  
  - `ReservationServiceTest` 보완 (null/없는 예약 검증 로직 추가)

# 👀 Checkpoints for Reviewers


# 📚 References & Resources


# 🎯 Related Issues
close#75 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 신기능
  * 리뷰 생성 API 추가(POST /api/reviews): 인증 사용자로 리뷰 등록(별점·댓글) 및 경험별 좋아요 평가 지원.
  * 예약·리뷰 도메인 서비스 및 저장소 추가로 생성·조회 흐름 완성.
* 리팩터
  * 별점 타입·컬럼 개선, 댓글 필드명 변경, 리뷰-경험 연관관계 및 예약당 1건 제약 강화, 경험 평가 필드명 정비.
* 테스트
  * 예약·리뷰 서비스 단위테스트 추가(성공·권한·중복·미존재·입력검증 등).
* 문서/에러
  * 오류 상태코드에 예약/중복리뷰/리뷰미존재/잘못된예약ID 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->