### PR TITLE
커피챗 등록, 수정 관련 로직 구현

### DIFF
--- a/src/main/java/coffeandcommit/crema/domain/guide/entity/TimeUnit.java
+++ b/src/main/java/coffeandcommit/crema/domain/guide/entity/TimeUnit.java
@@ -1,6 +1,7 @@
 package coffeandcommit.crema.domain.guide.entity;
 
 import coffeandcommit.crema.domain.guide.enums.TimeType;
+import coffeandcommit.crema.domain.reservation.entity.Reservation;
 import coffeandcommit.crema.global.common.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
@@ -15,11 +16,11 @@ import lombok.*;
     name = "time_unit",
     uniqueConstraints = {
         @UniqueConstraint(
-            columnNames = {"guide_id", "time_type"}
+            columnNames = {"reservation_id", "time_type"} // 예약별로 30분/60분 중 하나만
         )
     },
     indexes = {
-        @Index(columnList = "guide_id"),
+        @Index(columnList = "reservation_id"),
         @Index(columnList = "time_type")
     }
 )
@@ -29,14 +30,19 @@ public class TimeUnit extends BaseEntity{
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "guide_id", nullable = false)
-    private Guide guide; // FK, 가이드 ID
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reservation_id", nullable = false, unique = true)
+    private Reservation reservation;
 
     @Enumerated(EnumType.STRING)
-    private TimeType timeType; // 30분, 60분
+    @Column(name = "time_type", nullable = false)
+    private TimeType timeType;
 
-    @Column
-    private int price; // 가격
+    public void setReservation(Reservation reservation) {
+        this.reservation = reservation;
+        if (reservation.getTimeUnit() != this) {
+            reservation.setTimeUnit(this);
+        }
+    }
 
 }

--- a/src/main/java/coffeandcommit/crema/domain/guide/enums/TimeType.java
+++ b/src/main/java/coffeandcommit/crema/domain/guide/enums/TimeType.java
@@ -9,9 +9,10 @@ import lombok.ToString;
 @ToString
 public enum TimeType {
 
-    MINUTE_30(8000),
-    MINUTE_60(15000);
+    MINUTE_30(30, 8000),
+    MINUTE_60(60, 15000);
 
+    private final int minutes;
     private final int price;
 
 }

--- a/src/main/java/coffeandcommit/crema/domain/guide/enums/TimeType.java
+++ b/src/main/java/coffeandcommit/crema/domain/guide/enums/TimeType.java
@@ -9,7 +9,9 @@ import lombok.ToString;
 @ToString
 public enum TimeType {
 
-    MINUTE_30,
-    MINUTE_60
+    MINUTE_30(8000),
+    MINUTE_60(15000);
+
+    private final int price;
 
 }

--- a/src/main/java/coffeandcommit/crema/domain/reservation/controller/ReservationController.java
+++ b/src/main/java/coffeandcommit/crema/domain/reservation/controller/ReservationController.java
@@ -1,6 +1,8 @@
 package coffeandcommit.crema.domain.reservation.controller;
 
+import coffeandcommit.crema.domain.reservation.dto.request.ReservationDecisionRequestDTO;
 import coffeandcommit.crema.domain.reservation.dto.request.ReservationRequestDTO;
+import coffeandcommit.crema.domain.reservation.dto.response.ReservationDecisionResponseDTO;
 import coffeandcommit.crema.domain.reservation.dto.response.ReservationResponseDTO;
 import coffeandcommit.crema.domain.reservation.service.ReservationService;
 import coffeandcommit.crema.global.auth.service.CustomUserDetails;
@@ -14,10 +16,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RestController
@@ -44,6 +43,29 @@ public class ReservationController {
 
         Response<ReservationResponseDTO> response = Response.<ReservationResponseDTO>builder()
                 .message("커피챗 예약 신청 선공")
+                .data(result)
+                .build();
+
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "커피챗 예약 승인/거절", description = "커피챗 예약을 승인 또는 거절합니다.")
+    @PatchMapping("/{reservationId}")
+    public ResponseEntity<Response<ReservationDecisionResponseDTO>> decideReservation(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long reservationId,
+            @Valid @RequestBody ReservationDecisionRequestDTO reservationDecisionRequestDTO) {
+
+        if(userDetails == null){
+            throw new BaseException(ErrorStatus.UNAUTHORIZED);
+        }
+
+        String loginMemberId = userDetails.getMemberId();
+
+        ReservationDecisionResponseDTO result = reservationService.decideReservation(loginMemberId, reservationId, reservationDecisionRequestDTO);
+
+        Response<ReservationDecisionResponseDTO> response = Response.<ReservationDecisionResponseDTO>builder()
+                .message("커피챗 예약 승인/거절 성공")
                 .data(result)
                 .build();
 

--- a/src/main/java/coffeandcommit/crema/domain/reservation/controller/ReservationController.java
+++ b/src/main/java/coffeandcommit/crema/domain/reservation/controller/ReservationController.java
@@ -1,0 +1,52 @@
+package coffeandcommit.crema.domain.reservation.controller;
+
+import coffeandcommit.crema.domain.reservation.dto.request.ReservationRequestDTO;
+import coffeandcommit.crema.domain.reservation.dto.response.ReservationResponseDTO;
+import coffeandcommit.crema.domain.reservation.service.ReservationService;
+import coffeandcommit.crema.global.auth.service.CustomUserDetails;
+import coffeandcommit.crema.global.common.exception.BaseException;
+import coffeandcommit.crema.global.common.exception.code.ErrorStatus;
+import coffeandcommit.crema.global.common.response.Response;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/reservations")
+@RequiredArgsConstructor
+@Tag(name = "reservation" , description = "예약(커피챗) API")
+public class ReservationController {
+
+    private final ReservationService reservationService;
+
+    @Operation(summary = "커피챗 예약 신청", description = "커피챗 예약을 신청합니다.")
+    @PostMapping
+    public ResponseEntity<Response<ReservationResponseDTO>> createReservation(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Valid @RequestBody ReservationRequestDTO reservationRequestDTO) {
+
+        if(userDetails == null){
+            throw new BaseException(ErrorStatus.UNAUTHORIZED);
+        }
+
+        String loginMemberId = userDetails.getMemberId();
+
+        ReservationResponseDTO result = reservationService.createReservation(loginMemberId, reservationRequestDTO);
+
+        Response<ReservationResponseDTO> response = Response.<ReservationResponseDTO>builder()
+                .message("커피챗 예약 신청 선공")
+                .data(result)
+                .build();
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/coffeandcommit/crema/domain/reservation/dto/request/ReservationDecisionRequestDTO.java
+++ b/src/main/java/coffeandcommit/crema/domain/reservation/dto/request/ReservationDecisionRequestDTO.java
@@ -1,0 +1,20 @@
+package coffeandcommit.crema.domain.reservation.dto.request;
+
+import coffeandcommit.crema.domain.reservation.enums.Status;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ReservationDecisionRequestDTO {
+
+    @NotNull(message = "상태 값은 필수입니다.")
+    private Status status; // CONFIRMED or CANCELLED
+
+    private String reason; // CANCELLED일 때만 작성
+}

--- a/src/main/java/coffeandcommit/crema/domain/reservation/dto/request/ReservationRequestDTO.java
+++ b/src/main/java/coffeandcommit/crema/domain/reservation/dto/request/ReservationRequestDTO.java
@@ -1,0 +1,25 @@
+package coffeandcommit.crema.domain.reservation.dto.request;
+
+import coffeandcommit.crema.domain.guide.enums.TimeType;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ReservationRequestDTO {
+
+    @NotNull(message = "가이드 ID는 필수입니다.")
+    private Long guideId;
+
+    @NotNull(message = "시간 단위는 필수입니다.")
+    private TimeType timeUnit; // Enum (THIRTY_MINUTES, SIXTY_MINUTES)
+
+    @Valid
+    private SurveyRequestDTO survey; // 예약 시 함께 등록되는 사전자료
+}

--- a/src/main/java/coffeandcommit/crema/domain/reservation/dto/request/SurveyFileRequestDTO.java
+++ b/src/main/java/coffeandcommit/crema/domain/reservation/dto/request/SurveyFileRequestDTO.java
@@ -1,0 +1,17 @@
+package coffeandcommit.crema.domain.reservation.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class SurveyFileRequestDTO {
+
+    @NotBlank(message = "파일 업로드 URL은 필수입니다.")
+    private String fileUploadUrl; // 파일 업로드 URL (S3 경로)
+}

--- a/src/main/java/coffeandcommit/crema/domain/reservation/dto/request/SurveyRequestDTO.java
+++ b/src/main/java/coffeandcommit/crema/domain/reservation/dto/request/SurveyRequestDTO.java
@@ -1,0 +1,28 @@
+package coffeandcommit.crema.domain.reservation.dto.request;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class SurveyRequestDTO {
+
+    @NotBlank(message = "가이드에게 보낼 메시지는 필수입니다.")
+    private String messageToGuide; // 사전 메시지
+
+    @NotNull(message = "희망 날짜는 필수입니다.")
+    private LocalDateTime preferredDate; // 희망 날짜
+
+    @Valid
+    private List<@Valid SurveyFileRequestDTO> files; // 여러 개 파일 업로드
+}

--- a/src/main/java/coffeandcommit/crema/domain/reservation/dto/response/ReservationDecisionResponseDTO.java
+++ b/src/main/java/coffeandcommit/crema/domain/reservation/dto/response/ReservationDecisionResponseDTO.java
@@ -12,25 +12,24 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
-public class ReservationResponseDTO {
+public class ReservationDecisionResponseDTO {
 
     private Long reservationId;
     private Long guideId;
-    private String status; // Enum -> String 직렬화
-    private String timeUnit; // Enum -> String 직렬화
-    private SurveyResponseDTO survey;
-    private LocalDateTime preferredDate;
-    private LocalDateTime createdAt;
+    private String status;   // Enum → String
+    private String timeUnit; // Enum → String
+    private String reason;   // 거절 사유
+    private LocalDateTime updatedAt;
 
-    public static ReservationResponseDTO from(Reservation reservation) {
-        return ReservationResponseDTO.builder()
+    public static ReservationDecisionResponseDTO from(Reservation reservation) {
+        return ReservationDecisionResponseDTO.builder()
                 .reservationId(reservation.getId())
                 .guideId(reservation.getGuide().getId())
                 .status(reservation.getStatus().name())
                 .timeUnit(reservation.getTimeUnit().getTimeType().name())
-                .survey(SurveyResponseDTO.from(reservation.getSurvey()))
-                .preferredDate(reservation.getSurvey().getPreferredDate())
-                .createdAt(reservation.getCreatedAt())
+                .reason(reservation.getReason())
+                .updatedAt(reservation.getModifiedAt())
                 .build();
     }
+
 }

--- a/src/main/java/coffeandcommit/crema/domain/reservation/dto/response/ReservationResponseDTO.java
+++ b/src/main/java/coffeandcommit/crema/domain/reservation/dto/response/ReservationResponseDTO.java
@@ -1,0 +1,34 @@
+package coffeandcommit.crema.domain.reservation.dto.response;
+
+import coffeandcommit.crema.domain.reservation.entity.Reservation;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ReservationResponseDTO {
+
+    private Long reservationId;
+    private Long guideId;
+    private String status; // Enum -> String 직렬화
+    private String timeUnit; // Enum -> String 직렬화
+    private SurveyResponseDTO survey;
+    private LocalDateTime createdAt;
+
+    public static ReservationResponseDTO from(Reservation reservation) {
+        return ReservationResponseDTO.builder()
+                .reservationId(reservation.getId())
+                .guideId(reservation.getGuide().getId())
+                .status(reservation.getStatus().name())
+                .timeUnit(reservation.getTimeUnit().getTimeType().name())
+                .survey(SurveyResponseDTO.from(reservation.getSurvey()))
+                .createdAt(reservation.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/coffeandcommit/crema/domain/reservation/dto/response/SurveyFileResponseDTO.java
+++ b/src/main/java/coffeandcommit/crema/domain/reservation/dto/response/SurveyFileResponseDTO.java
@@ -1,0 +1,24 @@
+package coffeandcommit.crema.domain.reservation.dto.response;
+
+import coffeandcommit.crema.domain.reservation.entity.SurveyFile;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class SurveyFileResponseDTO {
+
+    private Long id;
+    private String fileUploadUrl;
+
+    public static SurveyFileResponseDTO from(SurveyFile file) {
+        return SurveyFileResponseDTO.builder()
+                .id(file.getId())
+                .fileUploadUrl(file.getFileUploadUrl())
+                .build();
+    }
+}

--- a/src/main/java/coffeandcommit/crema/domain/reservation/dto/response/SurveyResponseDTO.java
+++ b/src/main/java/coffeandcommit/crema/domain/reservation/dto/response/SurveyResponseDTO.java
@@ -1,0 +1,36 @@
+package coffeandcommit.crema.domain.reservation.dto.response;
+
+import coffeandcommit.crema.domain.reservation.entity.Survey;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class SurveyResponseDTO {
+
+    private Long id;
+    private String messageToGuide;
+    private LocalDateTime preferredDate;
+    private List<SurveyFileResponseDTO> files;
+
+    public static SurveyResponseDTO from(Survey survey) {
+        return SurveyResponseDTO.builder()
+                .id(survey.getId())
+                .messageToGuide(survey.getMessageToGuide())
+                .preferredDate(survey.getPreferredDate())
+                .files(
+                        survey.getFiles().stream()
+                                .map(SurveyFileResponseDTO::from)
+                                .collect(Collectors.toList())
+                )
+                .build();
+    }
+}

--- a/src/main/java/coffeandcommit/crema/domain/reservation/entity/Reservation.java
+++ b/src/main/java/coffeandcommit/crema/domain/reservation/entity/Reservation.java
@@ -37,6 +37,7 @@ public class Reservation extends BaseEntity{
     private LocalDateTime matchingTime;
 
     @Enumerated(EnumType.STRING)
+    @Builder.Default
     private Status status = Status.PENDING; // 예약 상태 (예: PENDING, CONFIRMED, COMPLETED)
 
     private String reason;

--- a/src/main/java/coffeandcommit/crema/domain/reservation/entity/Reservation.java
+++ b/src/main/java/coffeandcommit/crema/domain/reservation/entity/Reservation.java
@@ -37,7 +37,7 @@ public class Reservation extends BaseEntity{
     private LocalDateTime matchingTime;
 
     @Enumerated(EnumType.STRING)
-    private Status status; // 예약 상태 (예: PENDING, CONFIRMED, COMPLETED)
+    private Status status = Status.PENDING; // 예약 상태 (예: PENDING, CONFIRMED, COMPLETED)
 
     private String reason;
 
@@ -52,5 +52,15 @@ public class Reservation extends BaseEntity{
             timeUnit.setReservation(this); // 반대편도 세팅
         }
     }
+
+    public void setStatus(Status status) {
+        this.status = status;
+    }
+
+    public void setReason(String reason) {
+        this.reason = reason;
+    }
+
+
 
 }

--- a/src/main/java/coffeandcommit/crema/domain/reservation/entity/Reservation.java
+++ b/src/main/java/coffeandcommit/crema/domain/reservation/entity/Reservation.java
@@ -1,9 +1,9 @@
 package coffeandcommit.crema.domain.reservation.entity;
 
 import coffeandcommit.crema.domain.guide.entity.Guide;
+import coffeandcommit.crema.domain.guide.entity.TimeUnit;
 import coffeandcommit.crema.domain.member.entity.Member;
 import coffeandcommit.crema.domain.reservation.enums.Status;
-import coffeandcommit.crema.domain.survey.entity.Survey;
 import coffeandcommit.crema.global.common.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
@@ -42,4 +42,15 @@ public class Reservation extends BaseEntity{
     private String reason;
 
     private LocalDateTime reservedAt;
+
+    @OneToOne(mappedBy = "reservation", cascade = CascadeType.ALL, orphanRemoval = true)
+    private TimeUnit timeUnit;
+
+    public void setTimeUnit(TimeUnit timeUnit) {
+        this.timeUnit = timeUnit;
+        if (timeUnit.getReservation() != this) {
+            timeUnit.setReservation(this); // 반대편도 세팅
+        }
+    }
+
 }

--- a/src/main/java/coffeandcommit/crema/domain/reservation/entity/Survey.java
+++ b/src/main/java/coffeandcommit/crema/domain/reservation/entity/Survey.java
@@ -31,6 +31,7 @@ public class Survey extends BaseEntity{
     private LocalDateTime preferredDate; // 희망 날짜
 
     @OneToMany(mappedBy = "survey", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
     private List<SurveyFile> files = new ArrayList<>();
 
 }

--- a/src/main/java/coffeandcommit/crema/domain/reservation/entity/Survey.java
+++ b/src/main/java/coffeandcommit/crema/domain/reservation/entity/Survey.java
@@ -1,10 +1,12 @@
-package coffeandcommit.crema.domain.survey.entity;
+package coffeandcommit.crema.domain.reservation.entity;
 
 import coffeandcommit.crema.global.common.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 
 @Entity
@@ -27,5 +29,8 @@ public class Survey extends BaseEntity{
 
     @Column(name = "preferred_date",nullable = false)
     private LocalDateTime preferredDate; // 희망 날짜
+
+    @OneToMany(mappedBy = "survey", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<SurveyFile> files = new ArrayList<>();
 
 }

--- a/src/main/java/coffeandcommit/crema/domain/reservation/entity/SurveyFile.java
+++ b/src/main/java/coffeandcommit/crema/domain/reservation/entity/SurveyFile.java
@@ -1,0 +1,28 @@
+package coffeandcommit.crema.domain.reservation.entity;
+
+import coffeandcommit.crema.global.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder(toBuilder = true)
+@Table(name = "survey_file")
+public class SurveyFile extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "survey_id", nullable = false)
+    private Survey survey;
+
+    @Column(name = "file_upload_url", length = 2048)
+    private String fileUploadUrl; // 파일 업로드 URL (S3 경로)
+}

--- a/src/main/java/coffeandcommit/crema/domain/reservation/service/ReservationService.java
+++ b/src/main/java/coffeandcommit/crema/domain/reservation/service/ReservationService.java
@@ -1,13 +1,27 @@
 package coffeandcommit.crema.domain.reservation.service;
 
+import coffeandcommit.crema.domain.guide.entity.Guide;
+import coffeandcommit.crema.domain.guide.entity.TimeUnit;
+import coffeandcommit.crema.domain.guide.enums.TimeType;
+import coffeandcommit.crema.domain.guide.repository.GuideRepository;
+import coffeandcommit.crema.domain.member.entity.Member;
+import coffeandcommit.crema.domain.member.repository.MemberRepository;
+import coffeandcommit.crema.domain.reservation.dto.request.ReservationRequestDTO;
+import coffeandcommit.crema.domain.reservation.dto.response.ReservationResponseDTO;
 import coffeandcommit.crema.domain.reservation.entity.Reservation;
+import coffeandcommit.crema.domain.reservation.entity.Survey;
+import coffeandcommit.crema.domain.reservation.entity.SurveyFile;
+import coffeandcommit.crema.domain.reservation.enums.Status;
 import coffeandcommit.crema.domain.reservation.repository.ReservationRepository;
 import coffeandcommit.crema.global.common.exception.BaseException;
 import coffeandcommit.crema.global.common.exception.code.ErrorStatus;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Slf4j
 @Service
@@ -15,6 +29,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class ReservationService {
 
     private final ReservationRepository reservationRepository;
+    private final MemberRepository memberRepository;
+    private final GuideRepository guideRepository;
 
     /* 예약 존재 여부 확인 */
     @Transactional(readOnly = true)
@@ -24,5 +40,55 @@ public class ReservationService {
         }
         return reservationRepository.findById(reservationId)
                 .orElseThrow(() -> new BaseException(ErrorStatus.RESERVATION_NOT_FOUND));
+    }
+
+    /* 커피챗 예약 신청 */
+    @Transactional
+    public ReservationResponseDTO createReservation(String loginMemberId, @Valid ReservationRequestDTO reservationRequestDTO) {
+
+        // 1. 로그인한 사용자의 Guide 조회
+        Member member = memberRepository.findById(loginMemberId)
+                .orElseThrow(() -> new BaseException(ErrorStatus.MEMBER_NOT_FOUND));
+
+        // 2. 존재하는 가이드인지 확인
+        Guide guide = guideRepository.findById(reservationRequestDTO.getGuideId())
+                .orElseThrow(() -> new BaseException(ErrorStatus.GUIDE_NOT_FOUND));
+
+        // 3. Survey 엔티티 생성
+        Survey survey = Survey.builder()
+                .messageToGuide(reservationRequestDTO.getSurvey().getMessageToGuide())
+                .preferredDate(reservationRequestDTO.getSurvey().getPreferredDate())
+                .build();
+
+        // SurveyFile 엔티티 리스트 생성
+        List<SurveyFile> files = reservationRequestDTO.getSurvey().getFiles().stream()
+                .map(fileDto -> SurveyFile.builder()
+                        .survey(survey)
+                        .fileUploadUrl(fileDto.getFileUploadUrl())
+                        .build())
+                .toList();
+
+        survey.getFiles().addAll(files);
+
+
+        // 4. Reservation 엔티티 생성
+        Reservation reservation = Reservation.builder()
+                .member(member)
+                .guide(guide)
+                .status(Status.PENDING)
+                .survey(survey)
+                .build();
+
+        // 5. TimeUnit 엔티티 생성 (예약 ↔ 시간 단위 연결)
+        TimeUnit timeUnit = TimeUnit.builder()
+                .reservation(reservation)
+                .timeType(reservationRequestDTO.getTimeUnit()) // String -> Enum 변환
+                .build();
+
+        reservation.setTimeUnit(timeUnit);
+
+        Reservation saved = reservationRepository.save(reservation);
+
+        return ReservationResponseDTO.from(saved);
     }
 }

--- a/src/main/java/coffeandcommit/crema/domain/reservation/service/ReservationService.java
+++ b/src/main/java/coffeandcommit/crema/domain/reservation/service/ReservationService.java
@@ -2,7 +2,6 @@ package coffeandcommit.crema.domain.reservation.service;
 
 import coffeandcommit.crema.domain.guide.entity.Guide;
 import coffeandcommit.crema.domain.guide.entity.TimeUnit;
-import coffeandcommit.crema.domain.guide.enums.TimeType;
 import coffeandcommit.crema.domain.guide.repository.GuideRepository;
 import coffeandcommit.crema.domain.member.entity.Member;
 import coffeandcommit.crema.domain.member.repository.MemberRepository;
@@ -95,6 +94,7 @@ public class ReservationService {
     }
 
     /* 커피챗 예약 승인/거절 */
+    @Transactional
     public ReservationDecisionResponseDTO decideReservation(String loginMemberId, Long reservationId, @Valid ReservationDecisionRequestDTO reservationDecisionRequestDTO) {
 
         // 1. 예약 조회

--- a/src/main/java/coffeandcommit/crema/domain/review/entity/ReviewExperience.java
+++ b/src/main/java/coffeandcommit/crema/domain/review/entity/ReviewExperience.java
@@ -38,6 +38,7 @@ public class ReviewExperience extends BaseEntity {
     private ExperienceGroup experienceGroup; // FK, 경험 대주제 ID
 
     @Column(name = "is_thumbs_up", nullable = false)
+    @Builder.Default
     private boolean isThumbsUp = false; // 좋아요 여부
 
     public void setReview(Review review) {

--- a/src/main/java/coffeandcommit/crema/domain/review/entity/ReviewExperience.java
+++ b/src/main/java/coffeandcommit/crema/domain/review/entity/ReviewExperience.java
@@ -40,7 +40,7 @@ public class ReviewExperience extends BaseEntity {
     @Column(name = "is_thumbs_up", nullable = false)
     private boolean isThumbsUp = false; // 좋아요 여부
 
-    protected void setReview(Review review) {
+    public void setReview(Review review) {
         this.review = review;
     }
 }

--- a/src/main/java/coffeandcommit/crema/domain/review/service/ReviewService.java
+++ b/src/main/java/coffeandcommit/crema/domain/review/service/ReviewService.java
@@ -17,6 +17,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -36,6 +38,15 @@ public class ReviewService {
         // 2. 본인 예약 검증
         if (!reservation.getMember().getId().equals(loginMemberId)) {
             throw new BaseException(ErrorStatus.FORBIDDEN);
+        }
+
+        // 2-1. 리뷰 작성 가능 시점 검증
+        LocalDateTime startTime = reservation.getMatchingTime();
+        int minutes = reservation.getTimeUnit().getTimeType().getMinutes();
+        LocalDateTime endTime = startTime.plusMinutes(minutes);
+
+        if (LocalDateTime.now().isBefore(endTime)) {
+            throw new BaseException(ErrorStatus.REVIEW_NOT_ALLOWED_YET);
         }
 
         // 3. 중복 리뷰 방지

--- a/src/main/java/coffeandcommit/crema/global/common/exception/code/ErrorStatus.java
+++ b/src/main/java/coffeandcommit/crema/global/common/exception/code/ErrorStatus.java
@@ -63,8 +63,13 @@ public enum ErrorStatus implements BaseCode {
     // Review Domain
     RESERVATION_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 예약을 찾을 수 없습니다."),
     DUPLICATE_REVIEW(HttpStatus.CONFLICT, "이미 해당 예약에 대한 리뷰가 존재합니다."),
+    REVIEW_NOT_ALLOWED_YET(HttpStatus.BAD_REQUEST, "커피챗 종료 이후에만 리뷰를 작성할 수 있습니다."),
     REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 리뷰를 찾을 수 없습니다."),
-    INVALID_RESERVATION_ID(HttpStatus.BAD_REQUEST, "예약 ID는 null일 수 없습니다.");
+    INVALID_RESERVATION_ID(HttpStatus.BAD_REQUEST, "예약 ID는 null일 수 없습니다."),
+
+    // Reservation Domain
+    INVALID_STATUS(HttpStatus.BAD_REQUEST,"잘못된 예약 상태 요청입니다."),
+    ALREADY_DECIDED(HttpStatus.CONFLICT,"이미 처리된 예약입니다.");
 
 
 

--- a/src/test/java/coffeandcommit/crema/domain/reservation/service/ReservationServiceTest.java
+++ b/src/test/java/coffeandcommit/crema/domain/reservation/service/ReservationServiceTest.java
@@ -1,6 +1,21 @@
 package coffeandcommit.crema.domain.reservation.service;
 
+import coffeandcommit.crema.domain.guide.entity.Guide;
+import coffeandcommit.crema.domain.guide.entity.TimeUnit;
+import coffeandcommit.crema.domain.guide.enums.TimeType;
+import coffeandcommit.crema.domain.guide.repository.GuideRepository;
+import coffeandcommit.crema.domain.member.entity.Member;
+import coffeandcommit.crema.domain.member.repository.MemberRepository;
+import coffeandcommit.crema.domain.reservation.dto.request.ReservationDecisionRequestDTO;
+import coffeandcommit.crema.domain.reservation.dto.request.ReservationRequestDTO;
+import coffeandcommit.crema.domain.reservation.dto.request.SurveyFileRequestDTO;
+import coffeandcommit.crema.domain.reservation.dto.request.SurveyRequestDTO;
+import coffeandcommit.crema.domain.reservation.dto.response.ReservationDecisionResponseDTO;
+import coffeandcommit.crema.domain.reservation.dto.response.ReservationResponseDTO;
 import coffeandcommit.crema.domain.reservation.entity.Reservation;
+import coffeandcommit.crema.domain.reservation.entity.Survey;
+import coffeandcommit.crema.domain.reservation.entity.SurveyFile;
+import coffeandcommit.crema.domain.reservation.enums.Status;
 import coffeandcommit.crema.domain.reservation.repository.ReservationRepository;
 import coffeandcommit.crema.global.common.exception.BaseException;
 import coffeandcommit.crema.global.common.exception.code.ErrorStatus;
@@ -12,9 +27,14 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -23,18 +43,86 @@ class ReservationServiceTest {
     @Mock
     private ReservationRepository reservationRepository;
 
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private GuideRepository guideRepository;
+
     @InjectMocks
     private ReservationService reservationService;
 
     private Reservation testReservation;
+    private Member testMember;
+    private Guide testGuide;
+    private ReservationRequestDTO testReservationRequestDTO;
+    private ReservationDecisionRequestDTO testReservationDecisionRequestDTO;
     private final Long RESERVATION_ID = 1L;
+    private final String MEMBER_ID = "test-member-id";
+    private final Long GUIDE_ID = 1L;
 
     @BeforeEach
     void setUp() {
+        // Create test member
+        testMember = Member.builder()
+                .id(MEMBER_ID)
+                .point(20000) // Enough points for a reservation
+                .build();
+
+        // Create test guide
+        testGuide = Guide.builder()
+                .id(GUIDE_ID)
+                .member(Member.builder().id("guide-member-id").build())
+                .build();
+
+        // Create test survey request DTO
+        List<SurveyFileRequestDTO> fileRequestDTOs = Arrays.asList(
+            SurveyFileRequestDTO.builder()
+                .fileUploadUrl("https://example.com/file1.pdf")
+                .build()
+        );
+
+        SurveyRequestDTO surveyRequestDTO = SurveyRequestDTO.builder()
+                .messageToGuide("I would like to discuss career opportunities")
+                .preferredDate(LocalDateTime.now().plusDays(7))
+                .files(fileRequestDTOs)
+                .build();
+
+        // Create test reservation request DTO
+        testReservationRequestDTO = ReservationRequestDTO.builder()
+                .guideId(GUIDE_ID)
+                .timeUnit(TimeType.MINUTE_30)
+                .survey(surveyRequestDTO)
+                .build();
+
+        // Create test reservation decision request DTO for confirmation
+        testReservationDecisionRequestDTO = ReservationDecisionRequestDTO.builder()
+                .status(Status.CONFIRMED)
+                .build();
+
+        // Create a test survey
+        Survey testSurvey = Survey.builder()
+                .id(1L)
+                .messageToGuide("I would like to discuss career opportunities")
+                .preferredDate(LocalDateTime.now().plusDays(7))
+                .build();
+
+        // Create a test time unit
+        TimeUnit testTimeUnit = TimeUnit.builder()
+                .id(1L)
+                .timeType(TimeType.MINUTE_30)
+                .build();
+
         // Create a test reservation
         testReservation = Reservation.builder()
                 .id(RESERVATION_ID)
+                .guide(testGuide)
+                .member(testMember)
+                .status(Status.PENDING)
+                .survey(testSurvey)
                 .build();
+
+        testTimeUnit.setReservation(testReservation);
     }
 
     @Test
@@ -75,6 +163,199 @@ class ReservationServiceTest {
             reservationService.getReservationOrThrow(null);
         });
         assertEquals(ErrorStatus.INVALID_RESERVATION_ID, exception.getErrorCode());
+    }
 
+    @Test
+    @DisplayName("createReservation - 성공 케이스: 예약 생성 성공")
+    void createReservation_Success() {
+        // Given
+        when(memberRepository.findById(MEMBER_ID)).thenReturn(Optional.of(testMember));
+        when(guideRepository.findById(GUIDE_ID)).thenReturn(Optional.of(testGuide));
+        when(reservationRepository.save(any(Reservation.class))).thenReturn(testReservation);
+
+        // When
+        ReservationResponseDTO result = reservationService.createReservation(MEMBER_ID, testReservationRequestDTO);
+
+        // Then
+        assertNotNull(result);
+        assertEquals(RESERVATION_ID, result.getReservationId());
+        verify(memberRepository, times(1)).findById(MEMBER_ID);
+        verify(guideRepository, times(1)).findById(GUIDE_ID);
+        verify(reservationRepository, times(1)).save(any(Reservation.class));
+    }
+
+    @Test
+    @DisplayName("createReservation - 실패 케이스: 회원이 존재하지 않는 경우")
+    void createReservation_MemberNotFound() {
+        // Given
+        when(memberRepository.findById(MEMBER_ID)).thenReturn(Optional.empty());
+
+        // When & Then
+        BaseException exception = assertThrows(BaseException.class, () -> {
+            reservationService.createReservation(MEMBER_ID, testReservationRequestDTO);
+        });
+
+        assertEquals(ErrorStatus.MEMBER_NOT_FOUND, exception.getErrorCode());
+        verify(memberRepository, times(1)).findById(MEMBER_ID);
+        verify(guideRepository, never()).findById(any());
+        verify(reservationRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("createReservation - 실패 케이스: 가이드가 존재하지 않는 경우")
+    void createReservation_GuideNotFound() {
+        // Given
+        when(memberRepository.findById(MEMBER_ID)).thenReturn(Optional.of(testMember));
+        when(guideRepository.findById(GUIDE_ID)).thenReturn(Optional.empty());
+
+        // When & Then
+        BaseException exception = assertThrows(BaseException.class, () -> {
+            reservationService.createReservation(MEMBER_ID, testReservationRequestDTO);
+        });
+
+        assertEquals(ErrorStatus.GUIDE_NOT_FOUND, exception.getErrorCode());
+        verify(memberRepository, times(1)).findById(MEMBER_ID);
+        verify(guideRepository, times(1)).findById(GUIDE_ID);
+        verify(reservationRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("decideReservation - 성공 케이스: 예약 승인")
+    void decideReservation_ConfirmSuccess() {
+        // Given
+        String guideLoginId = "guide-member-id";
+        ReservationDecisionRequestDTO confirmRequest = ReservationDecisionRequestDTO.builder()
+                .status(Status.CONFIRMED)
+                .build();
+
+        when(reservationRepository.findById(RESERVATION_ID)).thenReturn(Optional.of(testReservation));
+
+        // When
+        ReservationDecisionResponseDTO result = reservationService.decideReservation(guideLoginId, RESERVATION_ID, confirmRequest);
+
+        // Then
+        assertNotNull(result);
+        assertEquals(Status.CONFIRMED.name(), result.getStatus());
+        verify(reservationRepository, times(1)).findById(RESERVATION_ID);
+    }
+
+    @Test
+    @DisplayName("decideReservation - 성공 케이스: 예약 거절")
+    void decideReservation_CancelSuccess() {
+        // Given
+        String guideLoginId = "guide-member-id";
+        String cancelReason = "Schedule conflict";
+        ReservationDecisionRequestDTO cancelRequest = ReservationDecisionRequestDTO.builder()
+                .status(Status.CANCELLED)
+                .reason(cancelReason)
+                .build();
+
+        when(reservationRepository.findById(RESERVATION_ID)).thenReturn(Optional.of(testReservation));
+
+        // When
+        ReservationDecisionResponseDTO result = reservationService.decideReservation(guideLoginId, RESERVATION_ID, cancelRequest);
+
+        // Then
+        assertNotNull(result);
+        assertEquals(Status.CANCELLED.name(), result.getStatus());
+        assertEquals(cancelReason, result.getReason());
+        verify(reservationRepository, times(1)).findById(RESERVATION_ID);
+    }
+
+    @Test
+    @DisplayName("decideReservation - 실패 케이스: 예약이 존재하지 않는 경우")
+    void decideReservation_ReservationNotFound() {
+        // Given
+        String guideLoginId = "guide-member-id";
+        when(reservationRepository.findById(RESERVATION_ID)).thenReturn(Optional.empty());
+
+        // When & Then
+        BaseException exception = assertThrows(BaseException.class, () -> {
+            reservationService.decideReservation(guideLoginId, RESERVATION_ID, testReservationDecisionRequestDTO);
+        });
+
+        assertEquals(ErrorStatus.RESERVATION_NOT_FOUND, exception.getErrorCode());
+        verify(reservationRepository, times(1)).findById(RESERVATION_ID);
+    }
+
+    @Test
+    @DisplayName("decideReservation - 실패 케이스: 이미 처리된 예약인 경우")
+    void decideReservation_AlreadyDecided() {
+        // Given
+        String guideLoginId = "guide-member-id";
+        Reservation alreadyConfirmedReservation = testReservation.toBuilder()
+                .status(Status.CONFIRMED)
+                .build();
+
+        when(reservationRepository.findById(RESERVATION_ID)).thenReturn(Optional.of(alreadyConfirmedReservation));
+
+        // When & Then
+        BaseException exception = assertThrows(BaseException.class, () -> {
+            reservationService.decideReservation(guideLoginId, RESERVATION_ID, testReservationDecisionRequestDTO);
+        });
+
+        assertEquals(ErrorStatus.ALREADY_DECIDED, exception.getErrorCode());
+        verify(reservationRepository, times(1)).findById(RESERVATION_ID);
+    }
+
+    @Test
+    @DisplayName("decideReservation - 실패 케이스: 로그인한 사용자가 해당 예약의 가이드가 아닌 경우")
+    void decideReservation_NotGuide() {
+        // Given
+        String wrongGuideLoginId = "wrong-guide-id";
+        when(reservationRepository.findById(RESERVATION_ID)).thenReturn(Optional.of(testReservation));
+
+        // When & Then
+        BaseException exception = assertThrows(BaseException.class, () -> {
+            reservationService.decideReservation(wrongGuideLoginId, RESERVATION_ID, testReservationDecisionRequestDTO);
+        });
+
+        assertEquals(ErrorStatus.FORBIDDEN, exception.getErrorCode());
+        verify(reservationRepository, times(1)).findById(RESERVATION_ID);
+    }
+
+    @Test
+    @DisplayName("decideReservation - 실패 케이스: 잘못된 상태값이 전달된 경우")
+    void decideReservation_InvalidStatus() {
+        // Given
+        String guideLoginId = "guide-member-id";
+        ReservationDecisionRequestDTO invalidStatusRequest = ReservationDecisionRequestDTO.builder()
+                .status(Status.PENDING) // PENDING은 허용되지 않음
+                .build();
+
+        when(reservationRepository.findById(RESERVATION_ID)).thenReturn(Optional.of(testReservation));
+
+        // When & Then
+        BaseException exception = assertThrows(BaseException.class, () -> {
+            reservationService.decideReservation(guideLoginId, RESERVATION_ID, invalidStatusRequest);
+        });
+
+        assertEquals(ErrorStatus.INVALID_STATUS, exception.getErrorCode());
+        verify(reservationRepository, times(1)).findById(RESERVATION_ID);
+    }
+
+    @Test
+    @DisplayName("decideReservation - 실패 케이스: 포인트가 부족한 경우")
+    void decideReservation_InsufficientPoints() {
+        // Given
+        String guideLoginId = "guide-member-id";
+        Member poorMember = Member.builder()
+                .id("poor-member-id")
+                .point(0) // 포인트 부족
+                .build();
+
+        Reservation reservationWithPoorMember = testReservation.toBuilder()
+                .member(poorMember)
+                .build();
+
+        when(reservationRepository.findById(RESERVATION_ID)).thenReturn(Optional.of(reservationWithPoorMember));
+
+        // When & Then
+        BaseException exception = assertThrows(BaseException.class, () -> {
+            reservationService.decideReservation(guideLoginId, RESERVATION_ID, testReservationDecisionRequestDTO);
+        });
+
+        assertEquals(ErrorStatus.INSUFFICIENT_POINTS, exception.getErrorCode());
+        verify(reservationRepository, times(1)).findById(RESERVATION_ID);
     }
 }

--- a/src/test/java/coffeandcommit/crema/domain/reservation/service/ReservationServiceTest.java
+++ b/src/test/java/coffeandcommit/crema/domain/reservation/service/ReservationServiceTest.java
@@ -14,7 +14,6 @@ import coffeandcommit.crema.domain.reservation.dto.response.ReservationDecisionR
 import coffeandcommit.crema.domain.reservation.dto.response.ReservationResponseDTO;
 import coffeandcommit.crema.domain.reservation.entity.Reservation;
 import coffeandcommit.crema.domain.reservation.entity.Survey;
-import coffeandcommit.crema.domain.reservation.entity.SurveyFile;
 import coffeandcommit.crema.domain.reservation.enums.Status;
 import coffeandcommit.crema.domain.reservation.repository.ReservationRepository;
 import coffeandcommit.crema.global.common.exception.BaseException;
@@ -28,7 +27,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;


### PR DESCRIPTION
## 💡 What’s this PR about?
- 리뷰 등록 기능 구현  
- 커피챗 예약 기능 구현  
- 커피챗 신청 시 예약 정보 조회 기능 구현  

---

## 🌸 What’s been done?
- **리뷰 등록 기능**
  - `ReviewRequestDTO`, `ReviewResponseDTO` 작성
  - 리뷰 엔티티 및 서비스 로직 구현
  - 리뷰 등록 API 컨트롤러 작성 (`POST /api/reviews`)
  - 리뷰 작성 시 유효성 검증 (별점 범위, 코멘트 최소/최대 길이 등)

- **커피챗 예약 기능**
  - `ReservationRequestDTO`, `ReservationResponseDTO` 작성
  - `Survey`, `SurveyFile` 분리 및 연관관계 설정 (`@OneToMany`, `@Builder.Default`)
  - 예약 생성 서비스 로직 구현 (`PENDING` 상태 기본값)
  - 예약 시 TimeUnit 매핑 및 가격 연동 로직 추가
  - 예약 생성 API 컨트롤러 작성 (`POST /api/reservations`)

- **커피챗 신청 시 조회 기능**
  - `ReservationDecisionRequestDTO`, `ReservationDecisionResponseDTO` 작성
  - 예약 상태 변경 API (`PATCH /api/reservations/{id}`) 구현
    - CONFIRMED: 멘티 포인트 차감, 가이드 포인트 적립
    - CANCELLED: 거절 사유 저장
  - 권한 검증 (해당 예약의 가이드만 승인/거절 가능)
  - 상태 변경 시 예외 처리 (`ALREADY_DECIDED`, `INVALID_STATUS`, `INSUFFICIENT_POINTS` 등)

---

## 🌿 Testing Details
- **리뷰 등록**
  - 리뷰 정상 등록 성공 케이스 검증
  - 유효성 검증 실패 케이스 테스트 (별점 범위 벗어남, 코멘트 길이 초과 등)

- **커피챗 예약**
  - `createReservation_Success` 단위 테스트 작성 (성공 시 예약 ID 반환 확인)
  - 멤버, 가이드가 존재하지 않을 경우 예외 발생 테스트
  - Survey 파일 업로드 포함/미포함 케이스 테스트

- **커피챗 신청 시 조회**
  - `decideReservation_Success` 단위 테스트 작성
    - CONFIRMED 시 포인트 차감/적립 검증
    - CANCELLED 시 거절 사유 반영 검증
  - 이미 처리된 예약에 대해 요청 시 `ALREADY_DECIDED` 예외 검증
  - 잘못된 상태값 요청 시 `INVALID_STATUS` 예외 검증

---

# 👀 Checkpoints for Reviewers



# 📚 References & Resources



# 🎯 Related Issues
close#78 
