### PR TITLE
내가 작성한 리뷰 조회 기능 구현

### DIFF
--- a/src/main/java/coffeandcommit/crema/domain/reservation/repository/ReservationRepository.java
+++ b/src/main/java/coffeandcommit/crema/domain/reservation/repository/ReservationRepository.java
@@ -2,16 +2,16 @@ package coffeandcommit.crema.domain.reservation.repository;
 
 import coffeandcommit.crema.domain.reservation.entity.Reservation;
 import coffeandcommit.crema.domain.reservation.enums.Status;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
-
-import java.util.List;
 
 @Repository
 public interface ReservationRepository extends JpaRepository<Reservation, Long> {
     int countByMember_IdAndStatus(String memberId, Status status);
 
     @EntityGraph(attributePaths = {"guide", "guide.member", "timeUnit"})
-    List<Reservation> findByMember_IdAndStatus(String memberId, Status status);
+    Page<Reservation> findByMember_IdAndStatus(String memberId, Status status, Pageable pageable);
 }

--- a/src/main/java/coffeandcommit/crema/domain/reservation/repository/ReservationRepository.java
+++ b/src/main/java/coffeandcommit/crema/domain/reservation/repository/ReservationRepository.java
@@ -6,6 +6,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -14,4 +16,30 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
 
     @EntityGraph(attributePaths = {"guide", "guide.member", "timeUnit"})
     Page<Reservation> findByMember_IdAndStatus(String memberId, Status status, Pageable pageable);
+
+    // WRITTEN → 리뷰가 존재하는 예약
+    @EntityGraph(attributePaths = {"guide", "guide.member", "timeUnit"})
+    @Query("""
+        select r from Reservation r
+        where r.member.id = :memberId
+          and r.status = :status
+          and exists (select 1 from Review rv where rv.reservation = r)
+    """)
+    Page<Reservation> findWrittenByMember(
+            @Param("memberId") String memberId,
+            @Param("status") Status status,
+            Pageable pageable);
+
+    // NOT_WRITTEN → 리뷰가 존재하지 않는 예약
+    @EntityGraph(attributePaths = {"guide", "guide.member", "timeUnit"})
+    @Query("""
+        select r from Reservation r
+        where r.member.id = :memberId
+          and r.status = :status
+          and not exists (select 1 from Review rv where rv.reservation = r)
+    """)
+    Page<Reservation> findNotWrittenByMember(
+            @Param("memberId") String memberId,
+            @Param("status") Status status,
+            Pageable pageable);
 }

--- a/src/main/java/coffeandcommit/crema/domain/reservation/repository/ReservationRepository.java
+++ b/src/main/java/coffeandcommit/crema/domain/reservation/repository/ReservationRepository.java
@@ -5,7 +5,11 @@ import coffeandcommit.crema.domain.reservation.enums.Status;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface ReservationRepository extends JpaRepository<Reservation, Long> {
     int countByMember_IdAndStatus(String memberId, Status status);
+
+    List<Reservation> findByMember_IdAndStatus(String memberId, Status status);
 }

--- a/src/main/java/coffeandcommit/crema/domain/reservation/repository/ReservationRepository.java
+++ b/src/main/java/coffeandcommit/crema/domain/reservation/repository/ReservationRepository.java
@@ -2,6 +2,7 @@ package coffeandcommit.crema.domain.reservation.repository;
 
 import coffeandcommit.crema.domain.reservation.entity.Reservation;
 import coffeandcommit.crema.domain.reservation.enums.Status;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -11,5 +12,6 @@ import java.util.List;
 public interface ReservationRepository extends JpaRepository<Reservation, Long> {
     int countByMember_IdAndStatus(String memberId, Status status);
 
+    @EntityGraph(attributePaths = {"guide", "guide.member", "timeUnit"})
     List<Reservation> findByMember_IdAndStatus(String memberId, Status status);
 }

--- a/src/main/java/coffeandcommit/crema/domain/review/controller/ReviewController.java
+++ b/src/main/java/coffeandcommit/crema/domain/review/controller/ReviewController.java
@@ -14,13 +14,12 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @Slf4j
 @RestController
@@ -57,7 +56,7 @@ public class ReviewController {
 
     @Operation(summary = "내 리뷰 조회", description = "로그인한 사용자가 작성했거나 작성 가능한 리뷰 목록을 조회합니다..")
     @GetMapping("/me")
-    public ResponseEntity<Response<List<MyReviewResponseDTO>>> getMyReviews(
+    public ResponseEntity<Response<Page<MyReviewResponseDTO>>> getMyReviews(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestParam(defaultValue = "ALL") String filter,
             @ParameterObject Pageable pageable) {
@@ -68,9 +67,9 @@ public class ReviewController {
 
         String loginMemberId = userDetails.getMemberId();
 
-        List<MyReviewResponseDTO> result = reviewService.getMyReviews(loginMemberId, filter, pageable);
+        Page<MyReviewResponseDTO> result = reviewService.getMyReviews(loginMemberId, filter, pageable);
 
-        Response<List<MyReviewResponseDTO>> response = Response.<List<MyReviewResponseDTO>>builder()
+        Response<Page<MyReviewResponseDTO>> response = Response.<Page<MyReviewResponseDTO>>builder()
                 .message("내 리뷰 조회 성공")
                 .data(result)
                 .build();

--- a/src/main/java/coffeandcommit/crema/domain/review/controller/ReviewController.java
+++ b/src/main/java/coffeandcommit/crema/domain/review/controller/ReviewController.java
@@ -13,6 +13,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -57,7 +59,8 @@ public class ReviewController {
     @GetMapping("/me")
     public ResponseEntity<Response<List<MyReviewResponseDTO>>> getMyReviews(
             @AuthenticationPrincipal CustomUserDetails userDetails,
-            @RequestParam(defaultValue = "ALL") String filter) {
+            @RequestParam(defaultValue = "ALL") String filter,
+            @ParameterObject Pageable pageable) {
 
         if (userDetails == null) {
             throw new BaseException(ErrorStatus.UNAUTHORIZED);
@@ -65,7 +68,7 @@ public class ReviewController {
 
         String loginMemberId = userDetails.getMemberId();
 
-        List<MyReviewResponseDTO> result = reviewService.getMyReviews(loginMemberId, filter);
+        List<MyReviewResponseDTO> result = reviewService.getMyReviews(loginMemberId, filter, pageable);
 
         Response<List<MyReviewResponseDTO>> response = Response.<List<MyReviewResponseDTO>>builder()
                 .message("내 리뷰 조회 성공")

--- a/src/main/java/coffeandcommit/crema/domain/review/controller/ReviewController.java
+++ b/src/main/java/coffeandcommit/crema/domain/review/controller/ReviewController.java
@@ -56,7 +56,8 @@ public class ReviewController {
     @Operation(summary = "내 리뷰 조회", description = "로그인한 사용자가 작성했거나 작성 가능한 리뷰 목록을 조회합니다..")
     @GetMapping("/me")
     public ResponseEntity<Response<List<MyReviewResponseDTO>>> getMyReviews(
-            @AuthenticationPrincipal CustomUserDetails userDetails) {
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(defaultValue = "ALL") String filter) {
 
         if (userDetails == null) {
             throw new BaseException(ErrorStatus.UNAUTHORIZED);
@@ -64,7 +65,7 @@ public class ReviewController {
 
         String loginMemberId = userDetails.getMemberId();
 
-        List<MyReviewResponseDTO> result = reviewService.getMyReviews(loginMemberId);
+        List<MyReviewResponseDTO> result = reviewService.getMyReviews(loginMemberId, filter);
 
         Response<List<MyReviewResponseDTO>> response = Response.<List<MyReviewResponseDTO>>builder()
                 .message("내 리뷰 조회 성공")

--- a/src/main/java/coffeandcommit/crema/domain/review/controller/ReviewController.java
+++ b/src/main/java/coffeandcommit/crema/domain/review/controller/ReviewController.java
@@ -1,6 +1,7 @@
 package coffeandcommit.crema.domain.review.controller;
 
 import coffeandcommit.crema.domain.review.dto.request.ReviewRequestDTO;
+import coffeandcommit.crema.domain.review.dto.response.MyReviewResponseDTO;
 import coffeandcommit.crema.domain.review.dto.response.ReviewResponseDTO;
 import coffeandcommit.crema.domain.review.service.ReviewService;
 import coffeandcommit.crema.global.auth.service.CustomUserDetails;
@@ -15,10 +16,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @Slf4j
 @RestController
@@ -51,6 +51,27 @@ public class ReviewController {
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
 
 
+    }
+
+    @Operation(summary = "내 리뷰 조회", description = "로그인한 사용자가 작성했거나 작성 가능한 리뷰 목록을 조회합니다..")
+    @GetMapping("/me")
+    public ResponseEntity<Response<List<MyReviewResponseDTO>>> getMyReviews(
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+        if (userDetails == null) {
+            throw new BaseException(ErrorStatus.UNAUTHORIZED);
+        }
+
+        String loginMemberId = userDetails.getMemberId();
+
+        List<MyReviewResponseDTO> result = reviewService.getMyReviews(loginMemberId);
+
+        Response<List<MyReviewResponseDTO>> response = Response.<List<MyReviewResponseDTO>>builder()
+                .message("내 리뷰 조회 성공")
+                .data(result)
+                .build();
+
+        return ResponseEntity.ok(response);
     }
 
 }

--- a/src/main/java/coffeandcommit/crema/domain/review/dto/response/GuideInfo.java
+++ b/src/main/java/coffeandcommit/crema/domain/review/dto/response/GuideInfo.java
@@ -1,0 +1,24 @@
+package coffeandcommit.crema.domain.review.dto.response;
+
+import coffeandcommit.crema.domain.guide.entity.Guide;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class GuideInfo {
+
+    private String nickname;         // 가이드 닉네임
+    private String profileImageUrl;
+
+    public static GuideInfo from(Guide guide) {
+        return GuideInfo.builder()
+                .nickname(guide.getMember().getNickname())
+                .profileImageUrl(guide.getMember().getProfileImageUrl())
+                .build();
+    }
+}

--- a/src/main/java/coffeandcommit/crema/domain/review/dto/response/MyReviewResponseDTO.java
+++ b/src/main/java/coffeandcommit/crema/domain/review/dto/response/MyReviewResponseDTO.java
@@ -1,0 +1,30 @@
+package coffeandcommit.crema.domain.review.dto.response;
+
+import coffeandcommit.crema.domain.reservation.entity.Reservation;
+import coffeandcommit.crema.domain.review.entity.Review;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MyReviewResponseDTO {
+
+    private Long reservationId;          // 예약 ID (항상 존재)
+
+    private GuideInfo guide;             // 가이드 정보
+    private ReservationInfo reservation; // 예약 정보
+    private ReviewInfo review;           // 리뷰 정보 (없으면 null)
+
+    public static MyReviewResponseDTO from(Reservation reservation, Review review) {
+        return MyReviewResponseDTO.builder()
+                .reservationId(reservation.getId())
+                .guide(GuideInfo.from(reservation.getGuide()))
+                .reservation(ReservationInfo.from(reservation))
+                .review(ReviewInfo.from(review))
+                .build();
+    }
+}

--- a/src/main/java/coffeandcommit/crema/domain/review/dto/response/MyReviewResponseDTO.java
+++ b/src/main/java/coffeandcommit/crema/domain/review/dto/response/MyReviewResponseDTO.java
@@ -2,6 +2,8 @@ package coffeandcommit.crema.domain.review.dto.response;
 
 import coffeandcommit.crema.domain.reservation.entity.Reservation;
 import coffeandcommit.crema.domain.review.entity.Review;
+import coffeandcommit.crema.global.common.exception.BaseException;
+import coffeandcommit.crema.global.common.exception.code.ErrorStatus;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -20,6 +22,10 @@ public class MyReviewResponseDTO {
     private ReviewInfo review;           // 리뷰 정보 (없으면 null)
 
     public static MyReviewResponseDTO from(Reservation reservation, Review review) {
+
+        if (reservation == null) {
+            throw new BaseException(ErrorStatus.RESERVATION_NOT_FOUND);
+        }
         return MyReviewResponseDTO.builder()
                 .reservationId(reservation.getId())
                 .guide(GuideInfo.from(reservation.getGuide()))

--- a/src/main/java/coffeandcommit/crema/domain/review/dto/response/ReservationInfo.java
+++ b/src/main/java/coffeandcommit/crema/domain/review/dto/response/ReservationInfo.java
@@ -1,0 +1,27 @@
+package coffeandcommit.crema.domain.review.dto.response;
+
+import coffeandcommit.crema.domain.guide.enums.TimeType;
+import coffeandcommit.crema.domain.reservation.entity.Reservation;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ReservationInfo {
+
+    private LocalDateTime matchingDateTime; // 확정된 커피챗 일시 (날짜+시간)
+    private TimeType timeUnit;
+
+    public static ReservationInfo from(Reservation reservation) {
+        return ReservationInfo.builder()
+                .matchingDateTime(reservation.getMatchingTime())
+                .timeUnit(reservation.getTimeUnit().getTimeType())
+                .build();
+    }
+}

--- a/src/main/java/coffeandcommit/crema/domain/review/dto/response/ReservationInfo.java
+++ b/src/main/java/coffeandcommit/crema/domain/review/dto/response/ReservationInfo.java
@@ -2,6 +2,8 @@ package coffeandcommit.crema.domain.review.dto.response;
 
 import coffeandcommit.crema.domain.guide.enums.TimeType;
 import coffeandcommit.crema.domain.reservation.entity.Reservation;
+import coffeandcommit.crema.global.common.exception.BaseException;
+import coffeandcommit.crema.global.common.exception.code.ErrorStatus;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -19,6 +21,10 @@ public class ReservationInfo {
     private TimeType timeUnit;
 
     public static ReservationInfo from(Reservation reservation) {
+
+        if (reservation.getTimeUnit() == null || reservation.getTimeUnit().getTimeType() == null) {
+            throw new BaseException(ErrorStatus.INTERNAL_SERVER_ERROR);
+        }
         return ReservationInfo.builder()
                 .matchingDateTime(reservation.getMatchingTime())
                 .timeUnit(reservation.getTimeUnit().getTimeType())

--- a/src/main/java/coffeandcommit/crema/domain/review/dto/response/ReviewInfo.java
+++ b/src/main/java/coffeandcommit/crema/domain/review/dto/response/ReviewInfo.java
@@ -1,0 +1,33 @@
+package coffeandcommit.crema.domain.review.dto.response;
+
+import coffeandcommit.crema.domain.review.entity.Review;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ReviewInfo {
+
+    private Long reviewId;            // 리뷰 PK (작성 전이면 없음)
+    private String comment;           // 리뷰 코멘트 (최대 100자)
+    private Double star;             // 리뷰 별점 (1~5)
+    private LocalDateTime createdAt;  // 리뷰 작성일
+
+    public static ReviewInfo from(Review review) {
+        if (review == null) {
+            return null;
+        }
+        return ReviewInfo.builder()
+                .reviewId(review.getId())
+                .comment(review.getComment() != null ? review.getComment() : "")
+                .star(review.getStarReview() != null ? review.getStarReview().doubleValue() : null)
+                .createdAt(review.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/coffeandcommit/crema/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/coffeandcommit/crema/domain/review/repository/ReviewRepository.java
@@ -7,6 +7,8 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -22,6 +24,6 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     """)
     Optional<Review> findByIdWithExperiences(@Param("id") Long id);
 
-    Optional<Review> findByReservationId(Long reservationId);
+    List<Review> findByReservationIdIn(Collection<Long> reservationIds);
 
 }

--- a/src/main/java/coffeandcommit/crema/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/coffeandcommit/crema/domain/review/repository/ReviewRepository.java
@@ -21,4 +21,7 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
         where r.id = :id
     """)
     Optional<Review> findByIdWithExperiences(@Param("id") Long id);
+
+    Optional<Review> findByReservationId(Long reservationId);
+
 }


### PR DESCRIPTION
# 🚀 What’s this PR about?
**작업 내용 요약:**  
- 리뷰 조회 API(`/api/review/me`) 구현  
- 예약 및 리뷰 상태를 기반으로 본인이 작성한 리뷰 목록을 조회할 수 있도록 기능 추가  

---

# ✨ What’s been done?
- `MyReviewResponseDTO` 설계 및 하위 DTO(`GuideInfo`, `ReservationInfo`, `ReviewInfo`) 구현  
  - 예약(`Reservation`) + 리뷰(`Review`) 정보를 하나의 응답 객체로 매핑  
  - 리뷰 미작성 시 `review: null` 로 내려가도록 처리  
- `ReviewService.getMyReviews(loginMemberId)` 로직 추가  
  - `ReservationRepository.findByMember_IdAndStatus(memberId, COMPLETED)` 활용  
  - 각 예약에 대해 `ReviewRepository.findByReservationId(reservationId)` 조회  
  - 리뷰 존재 시 → DTO 변환, 리뷰 미존재 시 → null 반환  
- 예외 처리
  - 완료된 예약이 없는 경우 `RESERVATION_NOT_FOUND` 예외 반환  
- 단위 테스트(`ReviewServiceTest`) 작성  
  - 리뷰가 있는 예약 / 없는 예약 혼합 케이스 검증  
  - 완료된 예약이 없을 때 예외 발생 검증  

---

# 🧪 Testing Details
- **테스트 코드 및 결과:**  
  - `getMyReviews_Success`: 완료된 예약 2건(리뷰 있음/없음 혼합) 정상 조회 검증  
  - `getMyReviews_NoReservationsFound`: 예약 없을 경우 `RESERVATION_NOT_FOUND` 예외 발생 검증  
- 테스트 커버리지:  
  - 리뷰 작성 여부에 따른 분기 처리 검증  
  - 예외 케이스 검증 완료  

# 👀 Checkpoints for Reviewers


# 📚 References & Resources


# 🎯 Related Issues
close#86 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 내 리뷰 조회 개선: 가이드 정보, 예약 시간 정보 및 작성된 리뷰(평점/코멘트/작성일)를 한 번에 반환.
  - 리뷰 유무 필터 추가: ALL / WRITTEN / NOT_WRITTEN로 목록 필터링.
  - GET /api/reviews/me (로그인 필요), 페이지네이션 지원.

- **개선**
  - 다수 예약에 대한 리뷰를 일괄 조회하여 응답 성능 및 매핑 효율 향상.

- **테스트**
  - 필터별 동작 및 예외 처리를 검증하는 단위 테스트 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->