### PR TITLE
가이드 커피챗 등록 및 조회 기능 구현

### DIFF
--- a/src/main/java/coffeandcommit/crema/domain/guide/controller/GuideController.java
+++ b/src/main/java/coffeandcommit/crema/domain/guide/controller/GuideController.java
@@ -136,7 +136,7 @@ public class GuideController {
     }
 
     @Operation(summary = "가이드 커피챗 조회", description = "특정 가이드의 커피챗 정보를 조회합니다.")
-    @GetMapping("/guides/{guideId}/coffeechats")
+    @GetMapping("/{guideId}/coffeechats")
     public ResponseEntity<Response<GuideCoffeeChatResponseDTO>> getGuideCoffeeChat(
             @PathVariable Long guideId,
             @AuthenticationPrincipal CustomUserDetails userDetails) {

--- a/src/main/java/coffeandcommit/crema/domain/guide/controller/GuideController.java
+++ b/src/main/java/coffeandcommit/crema/domain/guide/controller/GuideController.java
@@ -135,4 +135,24 @@ public class GuideController {
         return ResponseEntity.ok(response);
     }
 
+    @Operation(summary = "가이드 커피챗 조회", description = "특정 가이드의 커피챗 정보를 조회합니다.")
+    @GetMapping("/guides/{guideId}/coffeechats")
+    public ResponseEntity<Response<GuideCoffeeChatResponseDTO>> getGuideCoffeeChat(
+            @PathVariable Long guideId,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+        String loginMemberId = (userDetails != null) ? userDetails.getMemberId() : null;
+
+        GuideCoffeeChatResponseDTO result = guideService.getGuideCoffeeChat(guideId, loginMemberId);
+
+        Response<GuideCoffeeChatResponseDTO> response = Response.<GuideCoffeeChatResponseDTO>builder()
+                .message("가이드 커피챗 조회 성공")
+                .data(result)
+                .build();
+
+        return ResponseEntity.ok(response);
+
+    }
+
+
 }

--- a/src/main/java/coffeandcommit/crema/domain/guide/controller/GuideMeController.java
+++ b/src/main/java/coffeandcommit/crema/domain/guide/controller/GuideMeController.java
@@ -305,5 +305,27 @@ public class GuideMeController {
 
     }
 
+    @Operation(summary = "가이드 커피챗 등록", description = "가이드의 커피챗을 등록합니다.")
+    @PostMapping("/coffeechat")
+    public ResponseEntity<Response<GuideCoffeeChatResponseDTO>> registerGuideCoffeeChat(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Valid @RequestBody GuideCoffeeChatRequestDTO requestDTO) {
+
+        if (userDetails == null) {
+            throw new BaseException(ErrorStatus.UNAUTHORIZED);
+        }
+
+        String loginMemberId = userDetails.getMemberId();
+
+        GuideCoffeeChatResponseDTO result = guideMeService.registerGuideCoffeeChat(loginMemberId, requestDTO);
+
+        Response<GuideCoffeeChatResponseDTO> response = Response.<GuideCoffeeChatResponseDTO>builder()
+                .message("가이드 커피챗 등록 성공")
+                .data(result)
+                .build();
+
+        return ResponseEntity.ok(response);
+    }
+
 
 }

--- a/src/main/java/coffeandcommit/crema/domain/guide/dto/request/GuideCoffeeChatRequestDTO.java
+++ b/src/main/java/coffeandcommit/crema/domain/guide/dto/request/GuideCoffeeChatRequestDTO.java
@@ -1,0 +1,23 @@
+package coffeandcommit.crema.domain.guide.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class GuideCoffeeChatRequestDTO {
+
+    @NotBlank(message = "커피챗 제목은 필수 입력 값입니다.")
+    @Size(max = 200, message = "커피챗 제목은 최대 200자까지 가능합니다.")
+    private String title;
+
+    @NotBlank(message = "커피챗 소개글은 필수 입력 값입니다.")
+    @Size(max = 1000, message = "커피챗 소개글은 최대 1000자까지 가능합니다.")
+    private String chatDescription;
+}

--- a/src/main/java/coffeandcommit/crema/domain/guide/dto/response/GuideCoffeeChatResponseDTO.java
+++ b/src/main/java/coffeandcommit/crema/domain/guide/dto/response/GuideCoffeeChatResponseDTO.java
@@ -1,0 +1,61 @@
+package coffeandcommit.crema.domain.guide.dto.response;
+
+import coffeandcommit.crema.domain.guide.entity.Guide;
+import coffeandcommit.crema.domain.reservation.dto.response.GuideDTO;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class GuideCoffeeChatResponseDTO {
+
+    private GuideDTO guide; // 가이드 요약 정보
+
+    private boolean isOpen;
+
+    private String title;
+    private String chatDescription;
+
+    private List<GuideHashTagResponseDTO> tags; // 해시태그 목록
+
+    private Double reviewScore;
+    private Long reviewCount;
+
+    private GuideExperienceResponseDTO experiences; // 경험 그룹 (groups 배열 포함)
+
+    private GuideExperienceDetailResponseDTO experienceDetail; // 경험 상세 단건
+
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public static GuideCoffeeChatResponseDTO from(
+            Guide guide,
+            List<GuideHashTagResponseDTO> tags,
+            Double reviewScore,
+            Long reviewCount,
+            GuideExperienceResponseDTO experiences,
+            GuideExperienceDetailResponseDTO experienceDetail,
+            boolean isOpen
+    ) {
+        return GuideCoffeeChatResponseDTO.builder()
+                .guide(GuideDTO.from(guide))
+                .title(guide.getTitle())
+                .chatDescription(guide.getChatDescription())
+                .tags(tags)
+                .reviewScore(reviewScore)
+                .reviewCount(reviewCount)
+                .experiences(experiences)
+                .experienceDetail(experienceDetail)
+                .isOpen(isOpen)
+                .createdAt(guide.getCreatedAt())
+                .updatedAt(guide.getModifiedAt())
+                .build();
+    }
+}

--- a/src/main/java/coffeandcommit/crema/domain/guide/dto/response/GuideCoffeeChatResponseDTO.java
+++ b/src/main/java/coffeandcommit/crema/domain/guide/dto/response/GuideCoffeeChatResponseDTO.java
@@ -2,6 +2,7 @@ package coffeandcommit.crema.domain.guide.dto.response;
 
 import coffeandcommit.crema.domain.guide.entity.Guide;
 import coffeandcommit.crema.domain.reservation.dto.response.GuideDTO;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -18,7 +19,8 @@ public class GuideCoffeeChatResponseDTO {
 
     private GuideDTO guide; // 가이드 요약 정보
 
-    private boolean isOpen;
+    @JsonProperty("isOpened")
+    private boolean isOpened;
 
     private String title;
     private String chatDescription;
@@ -42,7 +44,7 @@ public class GuideCoffeeChatResponseDTO {
             Long reviewCount,
             GuideExperienceResponseDTO experiences,
             GuideExperienceDetailResponseDTO experienceDetail,
-            boolean isOpen
+            boolean isOpened
     ) {
         return GuideCoffeeChatResponseDTO.builder()
                 .guide(GuideDTO.from(guide))
@@ -53,7 +55,7 @@ public class GuideCoffeeChatResponseDTO {
                 .reviewCount(reviewCount)
                 .experiences(experiences)
                 .experienceDetail(experienceDetail)
-                .isOpen(isOpen)
+                .isOpened(isOpened)
                 .createdAt(guide.getCreatedAt())
                 .updatedAt(guide.getModifiedAt())
                 .build();

--- a/src/main/java/coffeandcommit/crema/domain/guide/entity/Guide.java
+++ b/src/main/java/coffeandcommit/crema/domain/guide/entity/Guide.java
@@ -26,9 +26,6 @@ public class Guide extends BaseEntity {
     @JoinColumn(name = "member_id", nullable = false, unique = true)
     private Member member; // FK, 멤버 ID는 String (UUID)
 
-    @Column(name = "is_approved", nullable = false)
-    private boolean isApproved;
-
     @Column(name = "chat_description", length = 1000)
     private String chatDescription;
 

--- a/src/main/java/coffeandcommit/crema/domain/guide/service/GuideMeService.java
+++ b/src/main/java/coffeandcommit/crema/domain/guide/service/GuideMeService.java
@@ -453,6 +453,7 @@ public class GuideMeService {
         Guide updatedGuide = guide.toBuilder()
                 .title(requestDTO.getTitle())
                 .chatDescription(requestDTO.getChatDescription())
+                .isOpened(true)
                 .build();
 
         guideRepository.save(updatedGuide);
@@ -479,9 +480,6 @@ public class GuideMeService {
                         .map(GuideExperienceDetailResponseDTO::from)
                         .orElse(null);
 
-        // 7-1. 오픈 여부
-        boolean isOpened = true;
-
         // 8. Response DTO 변환
         return GuideCoffeeChatResponseDTO.from(
                 updatedGuide,
@@ -490,7 +488,7 @@ public class GuideMeService {
                 reviewCount,
                 experiences,
                 experienceDetail,
-                isOpened
+                updatedGuide.isOpened()
         );
     }
 }

--- a/src/main/java/coffeandcommit/crema/domain/guide/service/GuideService.java
+++ b/src/main/java/coffeandcommit/crema/domain/guide/service/GuideService.java
@@ -141,6 +141,7 @@ public class GuideService {
     }
 
     /* 가이드 커피챗 조회 */
+    @Transactional(readOnly = true)
     public GuideCoffeeChatResponseDTO getGuideCoffeeChat(Long guideId, String loginMemberId) {
 
         // 1. 조회 대상 가이드 조회

--- a/src/main/java/coffeandcommit/crema/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/coffeandcommit/crema/domain/review/repository/ReviewRepository.java
@@ -26,7 +26,7 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
 
     List<Review> findByReservationIdIn(Collection<Long> reservationIds);
 
-    @Query("SELECT COALESCE(AVG(r.starReview), 0) FROM Review r WHERE r.reservation.guide.id = :guideId")
+    @Query("SELECT COALESCE(AVG(r.starReview), 0.0) FROM Review r WHERE r.reservation.guide.id = :guideId")
     Double getAverageScoreByGuideId(@Param("guideId") Long guideId);
 
     @Query("SELECT COUNT(r) FROM Review r WHERE r.reservation.guide.id = :guideId")

--- a/src/main/java/coffeandcommit/crema/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/coffeandcommit/crema/domain/review/repository/ReviewRepository.java
@@ -26,4 +26,9 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
 
     List<Review> findByReservationIdIn(Collection<Long> reservationIds);
 
+    @Query("SELECT COALESCE(AVG(r.starReview), 0) FROM Review r WHERE r.reservation.guide.id = :guideId")
+    Double getAverageScoreByGuideId(@Param("guideId") Long guideId);
+
+    @Query("SELECT COUNT(r) FROM Review r WHERE r.reservation.guide.id = :guideId")
+    Long countByGuideId(@Param("guideId") Long guideId);
 }

--- a/src/main/java/coffeandcommit/crema/global/auth/controller/TestAuthController.java
+++ b/src/main/java/coffeandcommit/crema/global/auth/controller/TestAuthController.java
@@ -159,7 +159,6 @@ public class TestAuthController {
     private void createTestGuideEntity(Member member) {
         Guide guide = Guide.builder()
                 .member(member)
-                .isApproved(true)      // 테스트용이므로 승인됨으로 설정
                 .isOpened(true)        // 테스트용이므로 공개로 설정
                 .title("테스트 가이드")
                 .companyName("테스트 회사")

--- a/src/test/java/coffeandcommit/crema/domain/guide/service/GuideMeServiceTest.java
+++ b/src/test/java/coffeandcommit/crema/domain/guide/service/GuideMeServiceTest.java
@@ -121,7 +121,6 @@ public class GuideMeServiceTest {
         guide = Guide.builder()
                 .id(1L)
                 .member(member)
-                .isApproved(true)
                 .chatDescription("description")
                 .isOpened(true)
                 .title("Test Guide")
@@ -1750,7 +1749,6 @@ public class GuideMeServiceTest {
                 .title("Old Title")
                 .chatDescription("Old Description")
                 .isOpened(false)
-                .isApproved(true)
                 .build();
 
         // 업데이트된 guide (save 시 반환)
@@ -1760,7 +1758,6 @@ public class GuideMeServiceTest {
                 .title("New Coffee Chat Title")
                 .chatDescription("New Coffee Chat Description")
                 .isOpened(true)
-                .isApproved(true)
                 .build();
 
         // 해시태그
@@ -1789,7 +1786,7 @@ public class GuideMeServiceTest {
         assertNotNull(result);
         assertEquals("New Coffee Chat Title", result.getTitle());
         assertEquals("New Coffee Chat Description", result.getChatDescription());
-        assertTrue(result.isOpen()); // 등록 시 무조건 true
+        assertTrue(result.isOpened()); // 등록 시 무조건 true
         assertEquals(4.5, result.getReviewScore());
         assertEquals(10L, result.getReviewCount());
         assertNotNull(result.getTags());

--- a/src/test/java/coffeandcommit/crema/domain/guide/service/GuideMeServiceTest.java
+++ b/src/test/java/coffeandcommit/crema/domain/guide/service/GuideMeServiceTest.java
@@ -6,6 +6,7 @@ import coffeandcommit.crema.domain.globalTag.enums.JobNameType;
 import coffeandcommit.crema.domain.globalTag.enums.TopicNameType;
 import coffeandcommit.crema.domain.globalTag.repository.ChatTopicRepository;
 import coffeandcommit.crema.domain.guide.dto.request.GuideChatTopicRequestDTO;
+import coffeandcommit.crema.domain.guide.dto.request.GuideCoffeeChatRequestDTO;
 import coffeandcommit.crema.domain.guide.dto.request.GuideExperienceDetailRequestDTO;
 import coffeandcommit.crema.domain.guide.dto.request.GuideExperienceRequestDTO;
 import coffeandcommit.crema.domain.guide.dto.request.GuideHashTagRequestDTO;
@@ -15,6 +16,7 @@ import coffeandcommit.crema.domain.guide.dto.request.GroupRequestDTO;
 import coffeandcommit.crema.domain.guide.dto.request.ScheduleRequestDTO;
 import coffeandcommit.crema.domain.guide.dto.request.TimeSlotRequestDTO;
 import coffeandcommit.crema.domain.guide.dto.response.GuideChatTopicResponseDTO;
+import coffeandcommit.crema.domain.guide.dto.response.GuideCoffeeChatResponseDTO;
 import coffeandcommit.crema.domain.guide.dto.response.GuideExperienceDetailResponseDTO;
 import coffeandcommit.crema.domain.guide.dto.response.GuideExperienceResponseDTO;
 import coffeandcommit.crema.domain.guide.dto.response.GuideHashTagResponseDTO;
@@ -37,6 +39,7 @@ import coffeandcommit.crema.domain.guide.repository.GuideRepository;
 import coffeandcommit.crema.domain.guide.repository.GuideScheduleRepository;
 import coffeandcommit.crema.domain.guide.repository.HashTagRepository;
 import coffeandcommit.crema.domain.guide.repository.TimeSlotRepository;
+import coffeandcommit.crema.domain.review.repository.ReviewRepository;
 import coffeandcommit.crema.domain.member.entity.Member;
 import coffeandcommit.crema.global.common.exception.BaseException;
 import coffeandcommit.crema.global.common.exception.code.ErrorStatus;
@@ -87,6 +90,9 @@ public class GuideMeServiceTest {
 
     @Mock
     private ExperienceGroupRepository experienceGroupRepository;
+
+    @Mock
+    private ReviewRepository reviewRepository;
 
     @InjectMocks
     private GuideMeService guideMeService;
@@ -1725,5 +1731,142 @@ public class GuideMeServiceTest {
         verify(experienceGroupRepository).countByGuide(guide);
         verify(guideChatTopicRepository).findById(999L);
         verify(experienceGroupRepository, never()).saveAll(any());
+    }
+
+    @Test
+    @DisplayName("registerGuideCoffeeChat 성공 테스트")
+    void registerGuideCoffeeChat_Success() {
+        // Given
+        String loginMemberId = memberId;
+        GuideCoffeeChatRequestDTO requestDTO = GuideCoffeeChatRequestDTO.builder()
+                .title("New Coffee Chat Title")
+                .chatDescription("New Coffee Chat Description")
+                .build();
+
+        // 기존 guide (조회 시 반환)
+        Guide guide = Guide.builder()
+                .id(1L)
+                .member(member)
+                .title("Old Title")
+                .chatDescription("Old Description")
+                .isOpened(false)
+                .isApproved(true)
+                .build();
+
+        // 업데이트된 guide (save 시 반환)
+        Guide updatedGuide = Guide.builder()
+                .id(1L) // ID 동일
+                .member(member)
+                .title("New Coffee Chat Title")
+                .chatDescription("New Coffee Chat Description")
+                .isOpened(true)
+                .isApproved(true)
+                .build();
+
+        // 해시태그
+        List<HashTag> hashTags = Arrays.asList(
+                HashTag.builder().id(1L).guide(updatedGuide).hashTagName("Java").build(),
+                HashTag.builder().id(2L).guide(updatedGuide).hashTagName("Spring").build()
+        );
+
+        // 경험 그룹 & 상세
+        List<ExperienceGroup> experienceGroups = new ArrayList<>();
+
+        // Stubbing
+        when(guideRepository.findByMember_Id(loginMemberId)).thenReturn(Optional.of(guide));
+        when(guideRepository.save(any(Guide.class))).thenReturn(updatedGuide);
+
+        when(hashTagRepository.findByGuide(any(Guide.class))).thenReturn(hashTags);
+        when(reviewRepository.getAverageScoreByGuideId(anyLong())).thenReturn(4.5);
+        when(reviewRepository.countByGuideId(anyLong())).thenReturn(10L);
+        when(experienceGroupRepository.findByGuide(any(Guide.class))).thenReturn(experienceGroups);
+        when(experienceDetailRepository.findByGuide(any(Guide.class))).thenReturn(Optional.of(experienceDetail));
+
+        // When
+        GuideCoffeeChatResponseDTO result = guideMeService.registerGuideCoffeeChat(loginMemberId, requestDTO);
+
+        // Then
+        assertNotNull(result);
+        assertEquals("New Coffee Chat Title", result.getTitle());
+        assertEquals("New Coffee Chat Description", result.getChatDescription());
+        assertTrue(result.isOpen()); // 등록 시 무조건 true
+        assertEquals(4.5, result.getReviewScore());
+        assertEquals(10L, result.getReviewCount());
+        assertNotNull(result.getTags());
+        assertEquals(2, result.getTags().size());
+        assertNotNull(result.getExperienceDetail());
+
+        // Verify
+        verify(guideRepository).findByMember_Id(loginMemberId);
+        verify(guideRepository).save(any(Guide.class));
+        verify(hashTagRepository).findByGuide(any(Guide.class));
+        verify(reviewRepository).getAverageScoreByGuideId(anyLong());
+        verify(reviewRepository).countByGuideId(anyLong());
+        verify(experienceGroupRepository).findByGuide(any(Guide.class));
+        verify(experienceDetailRepository).findByGuide(any(Guide.class));
+    }
+
+
+    @Test
+    @DisplayName("registerGuideCoffeeChat 가이드 없음 테스트")
+    void registerGuideCoffeeChat_GuideNotFound() {
+        // Given
+        String loginMemberId = "nonexistent-member-id";
+        GuideCoffeeChatRequestDTO requestDTO = GuideCoffeeChatRequestDTO.builder()
+                .title("New Coffee Chat Title")
+                .chatDescription("New Coffee Chat Description")
+                .build();
+
+        when(guideRepository.findByMember_Id(loginMemberId)).thenReturn(Optional.empty());
+
+        // When & Then
+        BaseException exception = assertThrows(BaseException.class, () -> 
+            guideMeService.registerGuideCoffeeChat(loginMemberId, requestDTO)
+        );
+
+        assertEquals(ErrorStatus.GUIDE_NOT_FOUND, exception.getErrorCode());
+
+        // Verify
+        verify(guideRepository).findByMember_Id(loginMemberId);
+        verifyNoMoreInteractions(guideRepository);
+        verifyNoInteractions(hashTagRepository, reviewRepository, experienceGroupRepository, experienceDetailRepository);
+    }
+
+    @Test
+    @DisplayName("registerGuideCoffeeChat 권한 없음 테스트")
+    void registerGuideCoffeeChat_Forbidden() {
+        // Given
+        String loginMemberId = "different-member-id";
+        GuideCoffeeChatRequestDTO requestDTO = GuideCoffeeChatRequestDTO.builder()
+                .title("New Coffee Chat Title")
+                .chatDescription("New Coffee Chat Description")
+                .build();
+
+        Member differentMember = Member.builder()
+                .id("different-member-id")
+                .nickname("Different Member")
+                .build();
+
+        Guide guideWithDifferentOwner = Guide.builder()
+                .id(1L)
+                .member(member) // Original member, not the login member
+                .title("Original Title")
+                .chatDescription("Original Description")
+                .isOpened(true)
+                .build();
+
+        when(guideRepository.findByMember_Id(loginMemberId)).thenReturn(Optional.of(guideWithDifferentOwner));
+
+        // When & Then
+        BaseException exception = assertThrows(BaseException.class, () -> 
+            guideMeService.registerGuideCoffeeChat(loginMemberId, requestDTO)
+        );
+
+        assertEquals(ErrorStatus.FORBIDDEN, exception.getErrorCode());
+
+        // Verify
+        verify(guideRepository).findByMember_Id(loginMemberId);
+        verifyNoMoreInteractions(guideRepository);
+        verifyNoInteractions(hashTagRepository, reviewRepository, experienceGroupRepository, experienceDetailRepository);
     }
 }

--- a/src/test/java/coffeandcommit/crema/domain/guide/service/GuideServiceTest.java
+++ b/src/test/java/coffeandcommit/crema/domain/guide/service/GuideServiceTest.java
@@ -110,7 +110,6 @@ public class GuideServiceTest {
                 .member(member1)
                 .isOpened(true)
                 .title("Guide 1")
-                .isApproved(true)
                 .build();
 
         guide2 = Guide.builder()
@@ -118,7 +117,6 @@ public class GuideServiceTest {
                 .member(member2)
                 .isOpened(false)  // Private guide
                 .title("Guide 2")
-                .isApproved(true)
                 .build();
 
         guideJobField = GuideJobField.builder()
@@ -955,7 +953,7 @@ public class GuideServiceTest {
         assertNotNull(result);
         assertEquals(guide1.getTitle(), result.getTitle());
         assertEquals(guide1.getChatDescription(), result.getChatDescription());
-        assertEquals(guide1.isOpened(), result.isOpen());
+        assertEquals(guide1.isOpened(), result.isOpened());
         assertEquals(4.5, result.getReviewScore());
         assertEquals(10L, result.getReviewCount());
         assertNotNull(result.getTags());
@@ -1043,7 +1041,7 @@ public class GuideServiceTest {
         // Then
         assertNotNull(result);
         assertEquals(guide2.getTitle(), result.getTitle());
-        assertEquals(guide2.isOpened(), result.isOpen());
+        assertEquals(guide2.isOpened(), result.isOpened());
         assertEquals(0.0, result.getReviewScore()); // Default value when no reviews
         assertEquals(0L, result.getReviewCount());
 

--- a/src/test/java/coffeandcommit/crema/domain/guide/service/GuideServiceTest.java
+++ b/src/test/java/coffeandcommit/crema/domain/guide/service/GuideServiceTest.java
@@ -5,6 +5,7 @@ import coffeandcommit.crema.domain.globalTag.enums.JobNameType;
 import coffeandcommit.crema.domain.globalTag.enums.TopicNameType;
 import coffeandcommit.crema.domain.guide.dto.response.GuideChatTopicResponseDTO;
 import coffeandcommit.crema.domain.guide.dto.response.GuideExperienceDetailResponseDTO;
+import coffeandcommit.crema.domain.guide.dto.response.GuideCoffeeChatResponseDTO;
 import coffeandcommit.crema.domain.guide.dto.response.GuideExperienceResponseDTO;
 import coffeandcommit.crema.domain.guide.dto.response.GuideHashTagResponseDTO;
 import coffeandcommit.crema.domain.guide.dto.response.GuideJobFieldResponseDTO;
@@ -25,6 +26,7 @@ import coffeandcommit.crema.domain.guide.repository.GuideJobFieldRepository;
 import coffeandcommit.crema.domain.guide.repository.GuideRepository;
 import coffeandcommit.crema.domain.guide.repository.GuideScheduleRepository;
 import coffeandcommit.crema.domain.guide.repository.HashTagRepository;
+import coffeandcommit.crema.domain.review.repository.ReviewRepository;
 import coffeandcommit.crema.domain.member.entity.Member;
 import coffeandcommit.crema.global.common.exception.BaseException;
 import coffeandcommit.crema.global.common.exception.code.ErrorStatus;
@@ -70,6 +72,9 @@ public class GuideServiceTest {
 
     @Mock
     private ExperienceGroupRepository experienceGroupRepository;
+
+    @Mock
+    private ReviewRepository reviewRepository;
 
     private Member member1;
     private Member member2;
@@ -925,5 +930,129 @@ public class GuideServiceTest {
         // 메서드 호출 검증
         verify(guideRepository).findById(1L);
         verify(experienceGroupRepository).findByGuide(guide1);
+    }
+    @Test
+    @DisplayName("getGuideCoffeeChat 성공 테스트")
+    void getGuideCoffeeChat_Success() {
+        // Given
+        Long guideId = 1L;
+        String loginMemberId = "member1";
+
+        List<HashTag> hashTags = Arrays.asList(hashTag1, hashTag2);
+        List<ExperienceGroup> experienceGroups = new ArrayList<>();
+
+        when(guideRepository.findById(guideId)).thenReturn(Optional.of(guide1));
+        when(hashTagRepository.findByGuide(guide1)).thenReturn(hashTags);
+        when(reviewRepository.getAverageScoreByGuideId(guideId)).thenReturn(4.5);
+        when(reviewRepository.countByGuideId(guideId)).thenReturn(10L);
+        when(experienceGroupRepository.findByGuide(guide1)).thenReturn(experienceGroups);
+        when(experienceDetailRepository.findByGuide(guide1)).thenReturn(Optional.of(experienceDetail));
+
+        // When
+        GuideCoffeeChatResponseDTO result = guideService.getGuideCoffeeChat(guideId, loginMemberId);
+
+        // Then
+        assertNotNull(result);
+        assertEquals(guide1.getTitle(), result.getTitle());
+        assertEquals(guide1.getChatDescription(), result.getChatDescription());
+        assertEquals(guide1.isOpened(), result.isOpen());
+        assertEquals(4.5, result.getReviewScore());
+        assertEquals(10L, result.getReviewCount());
+        assertNotNull(result.getTags());
+        assertEquals(2, result.getTags().size());
+        assertNotNull(result.getExperienceDetail());
+
+        // Verify
+        verify(guideRepository).findById(guideId);
+        verify(hashTagRepository).findByGuide(guide1);
+        verify(reviewRepository).getAverageScoreByGuideId(guideId);
+        verify(reviewRepository).countByGuideId(guideId);
+        verify(experienceGroupRepository).findByGuide(guide1);
+        verify(experienceDetailRepository).findByGuide(guide1);
+    }
+
+    @Test
+    @DisplayName("getGuideCoffeeChat 가이드 없음 테스트")
+    void getGuideCoffeeChat_GuideNotFound() {
+        // Given
+        Long guideId = 999L;
+        String loginMemberId = "member1";
+
+        when(guideRepository.findById(guideId)).thenReturn(Optional.empty());
+
+        // When & Then
+        BaseException exception = assertThrows(BaseException.class, () -> 
+            guideService.getGuideCoffeeChat(guideId, loginMemberId)
+        );
+
+        assertEquals(ErrorStatus.GUIDE_NOT_FOUND, exception.getErrorCode());
+
+        // Verify
+        verify(guideRepository).findById(guideId);
+        verifyNoInteractions(hashTagRepository, reviewRepository, experienceGroupRepository, experienceDetailRepository);
+    }
+
+    @Test
+    @DisplayName("getGuideCoffeeChat 비공개 가이드 접근 금지 테스트")
+    void getGuideCoffeeChat_ForbiddenAccessToPrivateGuide() {
+        // Given
+        Long guideId = 2L;
+        String loginMemberId = "member1"; // Not the owner of guide2
+
+        when(guideRepository.findById(guideId)).thenReturn(Optional.of(guide2)); // guide2 is private
+
+        // When & Then
+        BaseException exception = assertThrows(BaseException.class, () -> 
+            guideService.getGuideCoffeeChat(guideId, loginMemberId)
+        );
+
+        assertEquals(ErrorStatus.GUIDE_NOT_FOUND, exception.getErrorCode());
+
+        // Verify
+        verify(guideRepository).findById(guideId);
+        verifyNoInteractions(hashTagRepository, reviewRepository, experienceGroupRepository, experienceDetailRepository);
+    }
+
+    @Test
+    @DisplayName("getGuideCoffeeChat 비공개 가이드 소유자 접근 성공 테스트")
+    void getGuideCoffeeChat_OwnerCanAccessPrivateGuide() {
+        // Given
+        Long guideId = 2L;
+        String loginMemberId = "member2"; // Owner of guide2
+
+        List<HashTag> hashTags = new ArrayList<>();
+        List<ExperienceGroup> experienceGroups = new ArrayList<>();
+        ExperienceDetail privateExperienceDetail = ExperienceDetail.builder()
+                .id(2L)
+                .guide(guide2)
+                .who("경력 개발자")
+                .solution("이직 준비")
+                .how("포트폴리오 업데이트")
+                .build();
+
+        when(guideRepository.findById(guideId)).thenReturn(Optional.of(guide2));
+        when(hashTagRepository.findByGuide(guide2)).thenReturn(hashTags);
+        when(reviewRepository.getAverageScoreByGuideId(guideId)).thenReturn(null); // No reviews
+        when(reviewRepository.countByGuideId(guideId)).thenReturn(0L);
+        when(experienceGroupRepository.findByGuide(guide2)).thenReturn(experienceGroups);
+        when(experienceDetailRepository.findByGuide(guide2)).thenReturn(Optional.of(privateExperienceDetail));
+
+        // When
+        GuideCoffeeChatResponseDTO result = guideService.getGuideCoffeeChat(guideId, loginMemberId);
+
+        // Then
+        assertNotNull(result);
+        assertEquals(guide2.getTitle(), result.getTitle());
+        assertEquals(guide2.isOpened(), result.isOpen());
+        assertEquals(0.0, result.getReviewScore()); // Default value when no reviews
+        assertEquals(0L, result.getReviewCount());
+
+        // Verify
+        verify(guideRepository).findById(guideId);
+        verify(hashTagRepository).findByGuide(guide2);
+        verify(reviewRepository).getAverageScoreByGuideId(guideId);
+        verify(reviewRepository).countByGuideId(guideId);
+        verify(experienceGroupRepository).findByGuide(guide2);
+        verify(experienceDetailRepository).findByGuide(guide2);
     }
 }


### PR DESCRIPTION
# 🚀 What’s this PR about?
- **Guide Coffee Chat 등록 및 조회 기능 구현**
- 가이드가 본인 프로필에 커피챗을 등록할 수 있고, 다른 유저들이 공개된 경우 조회할 수 있도록 기능 추가

---

# 🛠 What’s been done?
- `GuideCoffeeChatRequestDTO`, `GuideCoffeeChatResponseDTO` 추가
- `GuideMeService.registerGuideCoffeeChat` 구현
  - 가이드 본인만 등록 가능 (`FORBIDDEN` 검증 추가)
  - 등록 시 자동으로 `isOpen = true` 상태로 응답
  - 리뷰 평균 별점 및 리뷰 개수 집계
  - 해시태그, 경험 그룹, 경험 상세 포함 응답
- `GuideService.getGuideCoffeeChat` 구현
  - 특정 가이드의 커피챗 조회
  - 본인은 항상 접근 가능, 타인은 `isOpen=true`일 때만 접근 가능
  - `validateAccess` 메서드 추가 (접근 제어 로직 분리)
- 테스트 코드 작성
  - `registerGuideCoffeeChat_Success` 단위 테스트 작성 및 검증
  - Mockito `any()` / `anyLong()` 활용하여 argument mismatch 문제 해결

---

# 🧪 Testing Details
- **테스트 코드 작성**
  - `registerGuideCoffeeChat_Success` → 가이드 본인이 정상적으로 커피챗 등록하는 케이스
  - 등록 후 응답에 `title`, `chatDescription`, `isOpen=true`, `reviewScore`, `reviewCount`, `tags`, `experienceDetail` 모두 정상 반환되는지 검증
- **리뷰 통계**
  - 평균 별점 소수점 첫째 자리 반올림 확인
  - 리뷰 개수(Long)로 반환 검증
- **Mocking 개선**
  - `hashTagRepository.findByGuide(any(Guide.class))` 등 유연한 매처 사용하여 `Strict stubbing mismatch` 문제 해결

# 👀 Checkpoints for Reviewers

# 📚 References & Resources


# 🎯 Related Issues
- close#60 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 가이드 커피챗 조회 추가: 리뷰 평점·개수, 태그, 경험(및 상세), 공개 여부 포함 조회 가능.
  - 내 가이드 커피챗 등록 추가: 제목·소개 입력으로 커피챗 등록 시 공개 처리.
  - 요청 유효성 강화: 제목(최대 200자)·소개(최대 1000자) 필수 검사 및 안내 메시지 제공.

- **Tests**
  - 서비스 레이어 주요 성공 및 예외 시나리오 단위 테스트 추가/확장.

- **Chores**
  - 가이드 승인 상태 관련 필드 제거 및 테스트 생성 로직 업데이트.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->