### PR TITLE
필터기반 가이드 리스트 조회 기능 구현

### DIFF
--- a/src/main/java/coffeandcommit/crema/domain/globalTag/enums/JobNameType.java
+++ b/src/main/java/coffeandcommit/crema/domain/globalTag/enums/JobNameType.java
@@ -1,5 +1,6 @@
 package coffeandcommit.crema.domain.globalTag.enums;
 
+import com.fasterxml.jackson.annotation.JsonValue;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.ToString;
@@ -18,4 +19,9 @@ public enum JobNameType {
     RESEARCH_RND("연구/R&D");
 
     private final String description;
+
+    @JsonValue
+    public String getDescription() {
+        return description;
+    }
 }

--- a/src/main/java/coffeandcommit/crema/domain/guide/dto/response/GuideListResponseDTO.java
+++ b/src/main/java/coffeandcommit/crema/domain/guide/dto/response/GuideListResponseDTO.java
@@ -1,0 +1,46 @@
+package coffeandcommit.crema.domain.guide.dto.response;
+
+import coffeandcommit.crema.domain.guide.entity.Guide;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class GuideListResponseDTO {
+
+    private Long guideId;
+    private String nickname;
+    private String profileImageUrl;
+    private String title;
+    private String workingPeriod; // "n년 n개월"
+
+    private GuideJobFieldResponseDTO jobField;
+    private List<GuideHashTagResponseDTO> hashTags;
+
+    private CoffeeChatStatsResponseDTO stats;
+
+    public static GuideListResponseDTO from(
+            Guide guide,
+            String workingPeriod,
+            GuideJobFieldResponseDTO jobField,
+            List<GuideHashTagResponseDTO> hashTags,
+            CoffeeChatStatsResponseDTO stats
+    ) {
+        return GuideListResponseDTO.builder()
+                .guideId(guide.getId())
+                .nickname(guide.getMember().getNickname())
+                .profileImageUrl(guide.getMember().getProfileImageUrl())
+                .title(guide.getTitle())
+                .workingPeriod(workingPeriod)
+                .jobField(jobField)
+                .hashTags(hashTags)
+                .stats(stats)
+                .build();
+    }
+}

--- a/src/main/java/coffeandcommit/crema/domain/guide/repository/GuideRepository.java
+++ b/src/main/java/coffeandcommit/crema/domain/guide/repository/GuideRepository.java
@@ -1,9 +1,14 @@
 package coffeandcommit.crema.domain.guide.repository;
 
 import coffeandcommit.crema.domain.guide.entity.Guide;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -11,4 +16,50 @@ public interface GuideRepository extends JpaRepository<Guide, Long> {
 
 
     Optional<Guide> findByMember_Id(String memberId);
+
+    /**
+     * 가이드 목록을 조회합니다.
+     * 조건에 따라 필터링된 가이드를 페이지 단위로 반환합니다.
+     * 영업 중(isOpened = true)인 가이드만 조회됩니다.
+     *
+     * @param jobFieldIds 직무분야 ID 목록
+     * @param chatTopicIds 커피챗 주제 ID 목록
+     * @param keyword 검색 키워드 (title, hashTagName)
+     * @param pageable 페이징 정보
+     * @return 필터링된 가이드 목록
+     */
+    @Query(
+        value = """
+            SELECT DISTINCT g
+            FROM Guide g
+            LEFT JOIN g.guideJobField gjf
+            LEFT JOIN g.guideChatTopics gct
+            LEFT JOIN g.hashTags ht
+            WHERE g.isOpened = true
+              AND (:jobFieldIds IS NULL OR gjf.id IN :jobFieldIds)
+              AND (:chatTopicIds IS NULL OR gct.chatTopic.id IN :chatTopicIds)
+              AND (:keyword IS NULL
+                   OR LOWER(g.title) LIKE LOWER(CONCAT('%', :keyword, '%'))
+                   OR LOWER(ht.hashTagName) LIKE LOWER(CONCAT('%', :keyword, '%')))
+            """,
+        countQuery = """
+            SELECT COUNT(DISTINCT g)
+            FROM Guide g
+            LEFT JOIN g.guideJobField gjf
+            LEFT JOIN g.guideChatTopics gct
+            LEFT JOIN g.hashTags ht
+            WHERE g.isOpened = true
+              AND (:jobFieldIds IS NULL OR gjf.id IN :jobFieldIds)
+              AND (:chatTopicIds IS NULL OR gct.chatTopic.id IN :chatTopicIds)
+              AND (:keyword IS NULL
+                   OR LOWER(g.title) LIKE LOWER(CONCAT('%', :keyword, '%'))
+                   OR LOWER(ht.hashTagName) LIKE LOWER(CONCAT('%', :keyword, '%')))
+            """
+    )
+    Page<Guide> findBySearchConditions(
+            @Param("jobFieldIds") List<Long> jobFieldIds,
+            @Param("chatTopicIds") List<Long> chatTopicIds,
+            @Param("keyword") String keyword,
+            Pageable pageable
+    );
 }

--- a/src/main/java/coffeandcommit/crema/domain/reservation/controller/ReservationController.java
+++ b/src/main/java/coffeandcommit/crema/domain/reservation/controller/ReservationController.java
@@ -14,9 +14,13 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 @Slf4j
 @RestController
@@ -28,10 +32,11 @@ public class ReservationController {
     private final ReservationService reservationService;
 
     @Operation(summary = "커피챗 예약 신청", description = "커피챗 예약을 신청합니다.")
-    @PostMapping
+    @PostMapping(consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
     public ResponseEntity<Response<ReservationResponseDTO>> createReservation(
             @AuthenticationPrincipal CustomUserDetails userDetails,
-            @Valid @RequestBody ReservationRequestDTO reservationRequestDTO) {
+            @Valid @RequestPart("reservation") ReservationRequestDTO reservationRequestDTO,
+            @RequestPart(value = "files", required = false) List<MultipartFile> files) {
 
         if(userDetails == null){
             throw new BaseException(ErrorStatus.UNAUTHORIZED);
@@ -39,7 +44,7 @@ public class ReservationController {
 
         String loginMemberId = userDetails.getMemberId();
 
-        ReservationResponseDTO result = reservationService.createReservation(loginMemberId, reservationRequestDTO);
+        ReservationResponseDTO result = reservationService.createReservation(loginMemberId, reservationRequestDTO, files);
 
         Response<ReservationResponseDTO> response = Response.<ReservationResponseDTO>builder()
                 .message("커피챗 예약 신청 성공")

--- a/src/main/java/coffeandcommit/crema/domain/reservation/dto/response/ReservationResponseDTO.java
+++ b/src/main/java/coffeandcommit/crema/domain/reservation/dto/response/ReservationResponseDTO.java
@@ -1,6 +1,7 @@
 package coffeandcommit.crema.domain.reservation.dto.response;
 
 import coffeandcommit.crema.domain.reservation.entity.Reservation;
+import coffeandcommit.crema.global.storage.StorageService;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -21,13 +22,13 @@ public class ReservationResponseDTO {
     private SurveyResponseDTO survey;
     private LocalDateTime createdAt;
 
-    public static ReservationResponseDTO from(Reservation reservation) {
+    public static ReservationResponseDTO from(Reservation reservation, StorageService storageService) {
         return ReservationResponseDTO.builder()
                 .reservationId(reservation.getId())
                 .guideId(reservation.getGuide().getId())
                 .status(reservation.getStatus().name())
                 .timeUnit(reservation.getTimeUnit().getTimeType().name())
-                .survey(SurveyResponseDTO.from(reservation.getSurvey()))
+                .survey(SurveyResponseDTO.from(reservation.getSurvey(), storageService))
                 .createdAt(reservation.getCreatedAt())
                 .build();
     }

--- a/src/main/java/coffeandcommit/crema/domain/reservation/dto/response/SurveyFileResponseDTO.java
+++ b/src/main/java/coffeandcommit/crema/domain/reservation/dto/response/SurveyFileResponseDTO.java
@@ -1,6 +1,7 @@
 package coffeandcommit.crema.domain.reservation.dto.response;
 
 import coffeandcommit.crema.domain.reservation.entity.SurveyFile;
+import coffeandcommit.crema.global.storage.StorageService;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,12 +14,12 @@ import lombok.NoArgsConstructor;
 public class SurveyFileResponseDTO {
 
     private Long id;
-    private String fileUploadUrl;
+    private String fileUrl;
 
-    public static SurveyFileResponseDTO from(SurveyFile file) {
+    public static SurveyFileResponseDTO from(SurveyFile file, StorageService storageService) {
         return SurveyFileResponseDTO.builder()
                 .id(file.getId())
-                .fileUploadUrl(file.getFileUploadUrl())
+                .fileUrl(storageService.generateViewUrl(file.getFileKey()))
                 .build();
     }
 }

--- a/src/main/java/coffeandcommit/crema/domain/reservation/dto/response/SurveyResponseDTO.java
+++ b/src/main/java/coffeandcommit/crema/domain/reservation/dto/response/SurveyResponseDTO.java
@@ -1,6 +1,7 @@
 package coffeandcommit.crema.domain.reservation.dto.response;
 
 import coffeandcommit.crema.domain.reservation.entity.Survey;
+import coffeandcommit.crema.global.storage.StorageService;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -21,14 +22,14 @@ public class SurveyResponseDTO {
     private LocalDateTime preferredDate;
     private List<SurveyFileResponseDTO> files;
 
-    public static SurveyResponseDTO from(Survey survey) {
+    public static SurveyResponseDTO from(Survey survey, StorageService storageService) {
         return SurveyResponseDTO.builder()
                 .id(survey.getId())
                 .messageToGuide(survey.getMessageToGuide())
                 .preferredDate(survey.getPreferredDate())
                 .files(
                         survey.getFiles().stream()
-                                .map(SurveyFileResponseDTO::from)
+                                .map(file -> SurveyFileResponseDTO.from(file, storageService))
                                 .collect(Collectors.toList())
                 )
                 .build();

--- a/src/main/java/coffeandcommit/crema/domain/reservation/entity/SurveyFile.java
+++ b/src/main/java/coffeandcommit/crema/domain/reservation/entity/SurveyFile.java
@@ -28,6 +28,6 @@ public class SurveyFile extends BaseEntity {
     @JoinColumn(name = "survey_id", nullable = false)
     private Survey survey;
 
-    @Column(name = "file_upload_url", length = 2048)
-    private String fileUploadUrl; // 파일 업로드 URL (S3 경로)
+    @Column(name = "file_Key", length = 2048)
+    private String fileKey; // 스토리지에 저장된 파일 Key
 }

--- a/src/main/java/coffeandcommit/crema/global/common/exception/code/ErrorStatus.java
+++ b/src/main/java/coffeandcommit/crema/global/common/exception/code/ErrorStatus.java
@@ -50,6 +50,7 @@ public enum ErrorStatus implements BaseCode {
 
     // Guide Domain
     GUIDE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 가이드를 찾을 수 없습니다."),
+    NO_GUIDES_FOUND(HttpStatus.NOT_FOUND, "조건에 맞는 가이드를 찾을 수 없습니다."),
     GUIDE_JOB_FIELD_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 가이드의 직무 분야를 찾을 수 없습니다."),
     INVALID_JOB_FIELD(HttpStatus.BAD_REQUEST, "잘못된 직무 분야 요청입니다."),
     INVALID_TOPIC(HttpStatus.BAD_REQUEST, "잘못된 주제 요청입니다."),

--- a/src/test/java/coffeandcommit/crema/domain/guide/service/GuideServiceTest.java
+++ b/src/test/java/coffeandcommit/crema/domain/guide/service/GuideServiceTest.java
@@ -1184,9 +1184,6 @@ public class GuideServiceTest {
         guide3 = guide3.toBuilder()
                 .guideJobField(guideJobField3)
                 .build();
-        guideJobField3 = guideJobField3.toBuilder()
-                .guide(guide3)
-                .build();
 
         // 페이지 객체 생성 (순서는 중요하지 않음, 서비스에서 재정렬됨)
         Page<Guide> guidePage = new PageImpl<>(List.of(guide1, guide3));

--- a/src/test/java/coffeandcommit/crema/domain/guide/service/GuideServiceTest.java
+++ b/src/test/java/coffeandcommit/crema/domain/guide/service/GuideServiceTest.java
@@ -38,10 +38,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 
-import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 

--- a/src/test/java/coffeandcommit/crema/domain/guide/service/GuideServiceTest.java
+++ b/src/test/java/coffeandcommit/crema/domain/guide/service/GuideServiceTest.java
@@ -3,13 +3,7 @@ package coffeandcommit.crema.domain.guide.service;
 import coffeandcommit.crema.domain.globalTag.entity.ChatTopic;
 import coffeandcommit.crema.domain.globalTag.enums.JobNameType;
 import coffeandcommit.crema.domain.globalTag.enums.TopicNameType;
-import coffeandcommit.crema.domain.guide.dto.response.GuideChatTopicResponseDTO;
-import coffeandcommit.crema.domain.guide.dto.response.GuideExperienceDetailResponseDTO;
-import coffeandcommit.crema.domain.guide.dto.response.GuideCoffeeChatResponseDTO;
-import coffeandcommit.crema.domain.guide.dto.response.GuideExperienceResponseDTO;
-import coffeandcommit.crema.domain.guide.dto.response.GuideHashTagResponseDTO;
-import coffeandcommit.crema.domain.guide.dto.response.GuideJobFieldResponseDTO;
-import coffeandcommit.crema.domain.guide.dto.response.GuideScheduleResponseDTO;
+import coffeandcommit.crema.domain.guide.dto.response.*;
 import coffeandcommit.crema.domain.guide.entity.ExperienceDetail;
 import coffeandcommit.crema.domain.guide.entity.ExperienceGroup;
 import coffeandcommit.crema.domain.guide.entity.Guide;
@@ -26,6 +20,9 @@ import coffeandcommit.crema.domain.guide.repository.GuideJobFieldRepository;
 import coffeandcommit.crema.domain.guide.repository.GuideRepository;
 import coffeandcommit.crema.domain.guide.repository.GuideScheduleRepository;
 import coffeandcommit.crema.domain.guide.repository.HashTagRepository;
+import coffeandcommit.crema.domain.reservation.enums.Status;
+import coffeandcommit.crema.domain.reservation.repository.ReservationRepository;
+import coffeandcommit.crema.domain.review.repository.ReviewExperienceRepository;
 import coffeandcommit.crema.domain.review.repository.ReviewRepository;
 import coffeandcommit.crema.domain.member.entity.Member;
 import coffeandcommit.crema.global.common.exception.BaseException;
@@ -37,9 +34,14 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 
@@ -75,6 +77,12 @@ public class GuideServiceTest {
 
     @Mock
     private ReviewRepository reviewRepository;
+
+    @Mock
+    private ReservationRepository reservationRepository;
+
+    @Mock
+    private ReviewExperienceRepository reviewExperienceRepository;
 
     private Member member1;
     private Member member2;
@@ -1053,4 +1061,175 @@ public class GuideServiceTest {
         verify(experienceGroupRepository).findByGuide(guide2);
         verify(experienceDetailRepository).findByGuide(guide2);
     }
+    @Test
+    @DisplayName("가이드 목록 조회 - 성공")
+    void getGuides_Success() {
+        // 테스트 데이터 준비
+        List<Long> jobFieldIds = List.of(1L);
+        List<Long> chatTopicIds = List.of(1L, 2L);
+        String keyword = "Java";
+        Pageable pageable = Pageable.unpaged();
+        String loginMemberId = "member1";
+        String sort = "latest";
+
+        guide1 = guide1.toBuilder()
+                .guideJobField(guideJobField)
+                .hashTags(List.of(hashTag1, hashTag2))
+                .build();
+        guideJobField = guideJobField.toBuilder()
+                .guide(guide1)
+                .build();
+
+        // 페이지 객체 생성
+        Page<Guide> guidePage = new PageImpl<>(List.of(guide1));
+
+        // Mock 설정
+        when(guideRepository.findBySearchConditions(jobFieldIds, chatTopicIds, keyword, pageable))
+                .thenReturn(guidePage);
+        when(reservationRepository.countByGuideAndStatus(guide1, Status.COMPLETED)).thenReturn(5L);
+        when(reviewRepository.calculateAverageStarByGuide(guide1)).thenReturn(java.math.BigDecimal.valueOf(4.5));
+        when(reviewRepository.countByGuide(guide1)).thenReturn(10L);
+        when(reviewExperienceRepository.countThumbsUpByGuide(guide1)).thenReturn(7L);
+
+        // 테스트 실행
+        Page<GuideListResponseDTO> result = guideService.getGuides(jobFieldIds, chatTopicIds, keyword, pageable, loginMemberId, sort);
+
+        // 검증
+        assertNotNull(result);
+        assertEquals(1, result.getTotalElements());
+        assertEquals(1, result.getContent().size());
+
+        GuideListResponseDTO dto = result.getContent().get(0);
+        assertEquals(guide1.getId(), dto.getGuideId());
+        assertEquals(guide1.getTitle(), dto.getTitle());
+        assertEquals(JobNameType.DESIGN, dto.getJobField().getJobName());
+        assertEquals(2, dto.getHashTags().size());
+        assertEquals(5L, dto.getStats().getTotalCoffeeChats());
+        assertEquals(4.5, dto.getStats().getAverageStar());
+        assertEquals(10L, dto.getStats().getTotalReviews());
+        assertEquals(7L, dto.getStats().getThumbsUpCount());
+
+        // 메서드 호출 검증
+        verify(guideRepository).findBySearchConditions(jobFieldIds, chatTopicIds, keyword, pageable);
+        verify(reservationRepository).countByGuideAndStatus(guide1, Status.COMPLETED);
+        verify(reviewRepository).calculateAverageStarByGuide(guide1);
+        verify(reviewRepository).countByGuide(guide1);
+        verify(reviewExperienceRepository).countThumbsUpByGuide(guide1);
+    }
+
+    @Test
+    @DisplayName("가이드 목록 조회 - 빈 결과")
+    void getGuides_EmptyResult() {
+        // 테스트 데이터 준비
+        List<Long> jobFieldIds = List.of(999L); // 존재하지 않는 ID
+        List<Long> chatTopicIds = null;
+        String keyword = null;
+        Pageable pageable = Pageable.unpaged();
+        String loginMemberId = "member1";
+        String sort = "latest";
+
+        // 빈 페이지 객체 생성
+        Page<Guide> emptyPage = new PageImpl<>(List.of());
+
+        // Mock 설정
+        when(guideRepository.findBySearchConditions(jobFieldIds, chatTopicIds, keyword, pageable))
+                .thenReturn(emptyPage);
+
+        // 테스트 실행
+        Page<GuideListResponseDTO> result = guideService.getGuides(jobFieldIds, chatTopicIds, keyword, pageable, loginMemberId, sort);
+
+        // 검증
+        assertNotNull(result);
+        assertEquals(0, result.getTotalElements());
+        assertTrue(result.getContent().isEmpty());
+
+        // 메서드 호출 검증
+        verify(guideRepository).findBySearchConditions(jobFieldIds, chatTopicIds, keyword, pageable);
+        verifyNoInteractions(reservationRepository, reviewRepository, reviewExperienceRepository);
+    }
+
+    @Test
+    @DisplayName("가이드 목록 조회 - 인기순 정렬")
+    void getGuides_SortByPopularity() {
+        // 테스트 데이터 준비
+        List<Long> jobFieldIds = null;
+        List<Long> chatTopicIds = null;
+        String keyword = null;
+        Pageable pageable = Pageable.unpaged();
+        String loginMemberId = "member1";
+        String sort = "popular";
+
+        // guide1에 jobField, hashTags 연결
+        guide1 = guide1.toBuilder()
+                .guideJobField(guideJobField)
+                .hashTags(List.of(hashTag1, hashTag2))
+                .build();
+        guideJobField = guideJobField.toBuilder()
+                .guide(guide1)
+                .build();
+
+        // 두 번째 가이드 생성 (더 많은 리뷰를 가진 가이드)
+        Guide guide3 = Guide.builder()
+                .id(3L)
+                .member(member1)
+                .isOpened(true)
+                .title("Guide 3")
+                .build();
+
+        GuideJobField guideJobField3 = GuideJobField.builder()
+                .id(3L)
+                .guide(guide3)
+                .jobName(JobNameType.IT_DEVELOPMENT_DATA)
+                .build();
+
+        // guide3에 jobField 연결
+        guide3 = guide3.toBuilder()
+                .guideJobField(guideJobField3)
+                .build();
+        guideJobField3 = guideJobField3.toBuilder()
+                .guide(guide3)
+                .build();
+
+        // 페이지 객체 생성 (순서는 중요하지 않음, 서비스에서 재정렬됨)
+        Page<Guide> guidePage = new PageImpl<>(List.of(guide1, guide3));
+
+        // Mock 설정
+        when(guideRepository.findBySearchConditions(jobFieldIds, chatTopicIds, keyword, pageable))
+                .thenReturn(guidePage);
+
+        // guide1 설정
+        when(reservationRepository.countByGuideAndStatus(guide1, Status.COMPLETED)).thenReturn(5L);
+        when(reviewRepository.calculateAverageStarByGuide(guide1)).thenReturn(java.math.BigDecimal.valueOf(4.5));
+        when(reviewRepository.countByGuide(guide1)).thenReturn(10L); // 리뷰 10개
+        when(reviewExperienceRepository.countThumbsUpByGuide(guide1)).thenReturn(7L);
+
+        // guide3 설정
+        when(reservationRepository.countByGuideAndStatus(guide3, Status.COMPLETED)).thenReturn(15L);
+        when(reviewRepository.calculateAverageStarByGuide(guide3)).thenReturn(java.math.BigDecimal.valueOf(4.8));
+        when(reviewRepository.countByGuide(guide3)).thenReturn(20L); // 리뷰 20개
+        when(reviewExperienceRepository.countThumbsUpByGuide(guide3)).thenReturn(12L);
+
+        // 테스트 실행
+        Page<GuideListResponseDTO> result = guideService.getGuides(
+                jobFieldIds, chatTopicIds, keyword, pageable, loginMemberId, sort);
+
+        // 검증
+        assertNotNull(result);
+        assertEquals(2, result.getTotalElements());
+        assertEquals(2, result.getContent().size());
+
+        // 인기순 정렬이므로 리뷰가 많은 guide3가 먼저 나와야 함
+        GuideListResponseDTO first = result.getContent().get(0);
+        GuideListResponseDTO second = result.getContent().get(1);
+
+        assertEquals(3L, first.getGuideId());
+        assertEquals(20L, first.getStats().getTotalReviews());
+
+        assertEquals(1L, second.getGuideId());
+        assertEquals(10L, second.getStats().getTotalReviews());
+
+        // 메서드 호출 검증
+        verify(guideRepository).findBySearchConditions(jobFieldIds, chatTopicIds, keyword, pageable);
+    }
+
 }


### PR DESCRIPTION
# 🚀 PR Description

# 🌸 What’s this PR about?
- 커피챗 예약 시 사전 설문 파일 업로드/저장 로직을 `FileService`/`StorageService` 기반으로 리팩터링했습니다.  
- 사전 정보 조회 시 저장된 `fileKey`를 Signed URL로 변환하여 응답하도록 수정했습니다.  
- 가이드 목록 조회 기능의 테스트 코드에서 `Guide ↔ GuideJobField` 관계 및 해시태그 세팅 로직을 보완하여 NPE 및 불필요한 stubbing 문제를 해결했습니다.  

---

# 🪄 What’s been done?
- **예약 생성 (createReservation)**  
  - `@RequestPart` 기반으로 `ReservationRequestDTO`와 `MultipartFile` 리스트를 함께 처리하도록 컨트롤러 수정  
  - 서비스 로직에서 `FileService.uploadFile`을 활용해 `fileKey` 저장  
  - `SurveyFile` 엔티티의 컬럼을 `fileUploadUrl → fileKey`로 변경  

- **사전 정보 조회 (getSurvey)**  
  - 저장된 `fileKey`를 기반으로 `StorageService.generateViewUrl()` 호출  
  - 응답 DTO(`SurveyFileResponseDTO`)에서 Signed URL을 내려주도록 변경  

- **DTO 변경**  
  - `ReservationResponseDTO`, `SurveyResponseDTO`에 `StorageService`를 주입받아 `SurveyFileResponseDTO` 변환 시 Signed URL을 포함  

- **가이드 목록 조회 서비스 및 테스트**  
  - `GuideListResponseDTO` 변환 시 `GuideJobField`, `HashTags`, `Stats` 매핑 로직 검증  
  - 테스트 코드에서 `Guide ↔ GuideJobField` 양방향 연결 및 해시태그 세팅 보완  
  - 인기순 정렬(popular) 케이스와 최신순 정렬(latest) 케이스 모두 테스트 검증  

---

# 🧪 Testing Details
- **테스트 코드 보완**  
  - 예약 생성 성공/실패 케이스에서 `files` 인자(null, empty, 정상 업로드) 모두 커버  
  - 가이드 목록 조회 성공 케이스에서 `GuideJobField`와 `HashTags`가 올바르게 매핑되는지 검증  
  - 인기순 정렬 시 리뷰 개수가 많은 가이드가 먼저 정렬되는지 확인  

# 👀 Checkpoints for Reviewers


# 📚 References & Resources


# 🎯 Related Issues
close#94 
