### PR TITLE
사전자료 조회 테스트 불가 해결

### DIFF
--- a/mock/init-dummy.json
+++ b/mock/init-dummy.json
@@ -1,0 +1,264 @@
+{
+  "members": [
+    {
+      "id": "MBR00001",
+      "nickname": "홍길동",
+      "role": "ROOKIE",
+      "point": 100,
+      "profileImageUrl": "https://cdn.example.com/profile1.png",
+      "description": "백엔드 지망생입니다.",
+      "provider": "GOOGLE",
+      "providerId": "google_123",
+      "isDeleted": false
+    },
+    {
+      "id": "MBR00002",
+      "nickname": "김선배",
+      "role": "GUIDE",
+      "point": 200,
+      "profileImageUrl": "https://cdn.example.com/profile2.png",
+      "description": "현직 백엔드 개발자입니다.",
+      "provider": "KAKAO",
+      "providerId": "kakao_456",
+      "isDeleted": false
+    },
+    {
+      "id": "MBR00003",
+      "nickname": "프론트가이드",
+      "role": "GUIDE",
+      "point": 150,
+      "profileImageUrl": "https://cdn.example.com/profile3.png",
+      "description": "프론트엔드 개발자입니다.",
+      "provider": "GOOGLE",
+      "providerId": "google_789",
+      "isDeleted": false
+    }
+  ],
+  "memberJobFields": [
+    { "id": 1, "memberId": "MBR00001", "jobName": "IT_DEVELOPMENT_DATA" },
+    { "id": 2, "memberId": "MBR00002", "jobName": "RESEARCH_RND" },
+    { "id": 3, "memberId": "MBR00003", "jobName": "IT_DEVELOPMENT_DATA" }
+  ],
+  "chatTopics": [
+    { "id": 1, "topicName": "INTERVIEW" },
+    { "id": 2, "topicName": "RESUME" },
+    { "id": 3, "topicName": "JOB_CHANGE" }
+  ],
+  "memberChatTopics": [
+    { "id": 1, "memberId": "MBR00001", "chatTopicId": 1 },
+    { "id": 2, "memberId": "MBR00001", "chatTopicId": 2 },
+    { "id": 3, "memberId": "MBR00002", "chatTopicId": 3 }
+  ],
+
+  "guides": [
+    {
+      "id": 1,
+      "memberId": "MBR00002",
+      "chatDescription": "커피챗으로 면접 준비 도와드립니다.",
+      "isOpened": true,
+      "title": "백엔드 면접/이직 상담",
+      "certificationImageUrl": "https://cdn.example.com/cert1.png",
+      "approvedDate": "2025-09-01T12:00:00",
+      "workingStart": "2020-01-01",
+      "workingEnd": null,
+      "workingPeriod": null,
+      "companyName": "네이버",
+      "isCompanyNamePublic": true,
+      "jobPosition": "Backend Engineer",
+      "isCurrent": true
+    },
+    {
+      "id": 2,
+      "memberId": "MBR00003",
+      "chatDescription": "프론트엔드 커리어/포트폴리오 상담합니다.",
+      "isOpened": true,
+      "title": "프론트엔드 커리어 상담",
+      "certificationImageUrl": "https://cdn.example.com/cert2.png",
+      "approvedDate": "2025-09-01T12:00:00",
+      "workingStart": "2019-03-01",
+      "workingEnd": null,
+      "workingPeriod": null,
+      "companyName": "카카오",
+      "isCompanyNamePublic": true,
+      "jobPosition": "Frontend Engineer",
+      "isCurrent": true
+    }
+  ],
+  "guideJobFields": [
+    { "id": 1, "guideId": 1, "jobName": "IT_DEVELOPMENT_DATA" },
+    { "id": 2, "guideId": 2, "jobName": "IT_DEVELOPMENT_DATA" }
+  ],
+  "guideChatTopics": [
+    { "id": 1, "guideId": 1, "chatTopicId": 1 },
+    { "id": 2, "guideId": 1, "chatTopicId": 3 },
+    { "id": 3, "guideId": 2, "chatTopicId": 1 },
+    { "id": 4, "guideId": 2, "chatTopicId": 2 }
+  ],
+  "hashTags": [
+    { "id": 1, "guideId": 1, "hashTagName": "#백엔드" },
+    { "id": 2, "guideId": 1, "hashTagName": "#면접준비" },
+    { "id": 3, "guideId": 2, "hashTagName": "#프론트엔드" },
+    { "id": 4, "guideId": 2, "hashTagName": "#포트폴리오" }
+  ],
+
+  "guideSchedules": [
+    { "id": 1, "guideId": 1, "dayOfWeek": "MONDAY" },
+    { "id": 2, "guideId": 1, "dayOfWeek": "WEDNESDAY" },
+    { "id": 3, "guideId": 2, "dayOfWeek": "TUESDAY" },
+    { "id": 4, "guideId": 2, "dayOfWeek": "THURSDAY" }
+  ],
+  "timeSlots": [
+    { "id": 1, "scheduleId": 1, "startTimeOption": "09:00:00", "endTimeOption": "12:00:00" },
+    { "id": 2, "scheduleId": 2, "startTimeOption": "14:00:00", "endTimeOption": "18:00:00" },
+    { "id": 3, "scheduleId": 3, "startTimeOption": "10:00:00", "endTimeOption": "12:00:00" },
+    { "id": 4, "scheduleId": 4, "startTimeOption": "19:00:00", "endTimeOption": "21:00:00" }
+  ],
+
+  "surveys": [
+    { "id": 1, "fileUploadUrl": "https://cdn.example.com/survey1-root.pdf", "messageToGuide": "면접 준비 조언 부탁드립니다.", "preferredDate": "2025-09-15 15:00:00" },
+    { "id": 2, "fileUploadUrl": "https://cdn.example.com/survey2-root.pdf", "messageToGuide": "자소서 피드백 받고 싶습니다.", "preferredDate": "2025-09-20 19:00:00" },
+    { "id": 3, "fileUploadUrl": "https://cdn.example.com/survey3-root.pdf", "messageToGuide": "프로젝트 코드 리뷰 받고 싶어요.", "preferredDate": "2025-09-22 20:00:00" },
+    { "id": 4, "fileUploadUrl": "https://cdn.example.com/survey4-root.pdf", "messageToGuide": "커리어 전환 조언 부탁드립니다.", "preferredDate": "2025-09-25 21:00:00" },
+    { "id": 5, "fileUploadUrl": "https://cdn.example.com/survey5-root.pdf", "messageToGuide": "포트폴리오 피드백 부탁드립니다.", "preferredDate": "2025-09-28 10:00:00" },
+    { "id": 6, "fileUploadUrl": "https://cdn.example.com/survey6-root.pdf", "messageToGuide": "프론트 면접 상담 부탁드립니다.", "preferredDate": "2025-09-29 10:00:00" },
+    { "id": 7, "fileUploadUrl": "https://cdn.example.com/survey7-root.pdf", "messageToGuide": "리액트 포트폴리오 문의드립니다.", "preferredDate": "2025-09-30 14:00:00" }
+  ],
+  "surveyFiles": [
+    { "id": 1, "surveyId": 1, "fileKey": "survey/1/file1.pdf" },
+    { "id": 2, "surveyId": 2, "fileKey": "survey/2/file1.pdf" },
+    { "id": 3, "surveyId": 3, "fileKey": "survey/3/file1.pdf" },
+    { "id": 4, "surveyId": 4, "fileKey": "survey/4/file1.pdf" },
+    { "id": 5, "surveyId": 5, "fileKey": "survey/5/file1.pdf" },
+    { "id": 6, "surveyId": 6, "fileKey": "survey/6/file1.pdf" },
+    { "id": 7, "surveyId": 7, "fileKey": "survey/7/file1.pdf" }
+  ],
+
+  "reservations": [
+    { "id": 1, "guideId": 1, "memberId": "MBR00001", "surveyId": 1, "matchingTime": "2025-09-15 15:00:00", "status": "COMPLETED" },
+    { "id": 2, "guideId": 1, "memberId": "MBR00001", "surveyId": 2, "matchingTime": "2025-09-20 19:00:00", "status": "PENDING" },
+    { "id": 3, "guideId": 1, "memberId": "MBR00001", "surveyId": 3, "matchingTime": "2025-09-22 20:00:00", "status": "COMPLETED" },
+    { "id": 4, "guideId": 1, "memberId": "MBR00001", "surveyId": 4, "matchingTime": "2025-09-25 21:00:00", "status": "COMPLETED" },
+    { "id": 5, "guideId": 1, "memberId": "MBR00001", "surveyId": 5, "matchingTime": "2025-09-28 10:00:00", "status": "COMPLETED" },
+    { "id": 6, "guideId": 2, "memberId": "MBR00001", "surveyId": 6, "matchingTime": "2025-09-29 10:00:00", "status": "PENDING" },
+    { "id": 7, "guideId": 2, "memberId": "MBR00001", "surveyId": 7, "matchingTime": "2025-09-30 14:00:00", "status": "PENDING" }
+  ],
+  "timeUnits": [
+    { "id": 1, "reservationId": 1, "timeType": "MINUTE_30" },
+    { "id": 2, "reservationId": 2, "timeType": "MINUTE_60" },
+    { "id": 3, "reservationId": 3, "timeType": "MINUTE_30" },
+    { "id": 4, "reservationId": 4, "timeType": "MINUTE_60" },
+    { "id": 5, "reservationId": 5, "timeType": "MINUTE_30" },
+    { "id": 6, "reservationId": 6, "timeType": "MINUTE_30" },
+    { "id": 7, "reservationId": 7, "timeType": "MINUTE_60" }
+  ],
+
+  "reviews": [
+    { "id": 1, "reservationId": 1, "comment": "면접 팁이 정말 유익했습니다!", "starReview": 4.5 },
+    { "id": 2, "reservationId": 3, "comment": "프로젝트 코드 리뷰가 큰 도움이 됐어요.", "starReview": 5.0 },
+    { "id": 3, "reservationId": 4, "comment": "커리어 전환 방향성을 잡을 수 있었어요.", "starReview": 4.0 },
+    { "id": 4, "reservationId": 5, "comment": "포트폴리오 개선 포인트를 알게 되었어요.", "starReview": 3.5 },
+    { "id": 8, "reservationId": 6, "comment": "프론트 면접 팁이 유익했어요.", "starReview": 4.5 },
+    { "id": 9, "reservationId": 7, "comment": "포트폴리오 피드백 좋았어요.", "starReview": 4.0 }
+  ],
+  "experienceGroups": [
+    { "id": 1, "guideId": 1, "guideChatTopicId": 1, "experienceTitle": "면접 경험", "experienceContent": "삼성전자 면접 합격 경험" },
+    { "id": 2, "guideId": 1, "guideChatTopicId": 2, "experienceTitle": "이직 경험", "experienceContent": "스타트업 → 대기업 전환기 이야기" },
+    { "id": 3, "guideId": 2, "guideChatTopicId": 3, "experienceTitle": "프론트 면접 경험", "experienceContent": "카카오 면접 합격 경험" },
+    { "id": 4, "guideId": 2, "guideChatTopicId": 4, "experienceTitle": "포트폴리오 리뷰", "experienceContent": "리액트 포트폴리오 개선 사례" }
+  ],
+  "experienceDetails": [
+    { "id": 1, "guideId": 1, "who": "신입 지원자", "solution": "코딩테스트 대비", "how": "스터디 그룹 운영" },
+    { "id": 2, "guideId": 2, "who": "주니어 프론트엔드", "solution": "포트폴리오 개선", "how": "컴포넌트 구조 리팩토링" }
+  ],
+  "reviewExperiences": [
+    { "id": 1, "reviewId": 1, "experienceGroupId": 1, "isThumbsUp": true },
+    { "id": 2, "reviewId": 2, "experienceGroupId": 1, "isThumbsUp": true },
+    { "id": 3, "reviewId": 3, "experienceGroupId": 2, "isThumbsUp": true },
+    { "id": 4, "reviewId": 4, "experienceGroupId": 2, "isThumbsUp": false },
+    { "id": 5, "reviewId": 8, "experienceGroupId": 3, "isThumbsUp": true },
+    { "id": 6, "reviewId": 9, "experienceGroupId": 4, "isThumbsUp": true }
+  ],
+
+  "meetingRooms": [
+    { "id": 1, "reservationId": 1, "startTime": "2025-09-15 15:00:00", "endTime": "2025-09-15 15:30:00", "roomUrl": "https://meet.example.com/room1" }
+  ],
+  "candidates": [
+    { "id": 1, "reservationId": 1, "timeId": 1, "priority": 1, "candidateDate": "2025-09-14 10:00:00" },
+    { "id": 2, "reservationId": 2, "timeId": 2, "priority": 2, "candidateDate": "2025-09-19 15:00:00" }
+  ],
+  "notifications": [
+    { "id": 1, "memberId": "MBR00001", "reservationId": 1, "message": "예약이 확정되었습니다.", "isRead": false },
+    { "id": 2, "memberId": "MBR00002", "reservationId": 1, "message": "새로운 후기가 등록되었습니다.", "isRead": false }
+  ],
+
+  "apiExamples": {
+    "guidesList": {
+      "page": 0,
+      "size": 20,
+      "totalElements": 2,
+      "content": [
+        {
+          "guideId": 1,
+          "nickname": "김선배",
+          "profileImageUrl": "https://cdn.example.com/profile2.png",
+          "title": "백엔드 면접/이직 상담",
+          "workingPeriod": null,
+          "jobField": { "guideId": 1, "jobName": "IT_DEVELOPMENT_DATA" },
+          "hashTags": [
+            { "id": 1, "guideId": 1, "hashTagName": "#백엔드" },
+            { "id": 2, "guideId": 1, "hashTagName": "#면접준비" }
+          ],
+          "stats": { "totalCoffeeChats": 4, "averageStar": 4.3, "totalReviews": 4, "thumbsUpCount": 3 }
+        },
+        {
+          "guideId": 2,
+          "nickname": "프론트가이드",
+          "profileImageUrl": "https://cdn.example.com/profile3.png",
+          "title": "프론트엔드 커리어 상담",
+          "workingPeriod": null,
+          "jobField": { "guideId": 2, "jobName": "IT_DEVELOPMENT_DATA" },
+          "hashTags": [
+            { "id": 3, "guideId": 2, "hashTagName": "#프론트엔드" },
+            { "id": 4, "guideId": 2, "hashTagName": "#포트폴리오" }
+          ],
+          "stats": { "totalCoffeeChats": 0, "averageStar": 4.3, "totalReviews": 2, "thumbsUpCount": 2 }
+        }
+      ]
+    },
+    "guide2ChatTopics": [
+      { "id": 3, "guideId": 2, "topic": { "topicName": "INTERVIEW" } },
+      { "id": 4, "guideId": 2, "topic": { "topicName": "RESUME" } }
+    ],
+    "guide2Schedules": {
+      "guideId": 2,
+      "schedules": [
+        { "id": 3, "dayOfWeek": "TUESDAY", "timeSlots": [ { "id": 3, "startTimeOption": "10:00:00", "endTimeOption": "12:00:00" } ] },
+        { "id": 4, "dayOfWeek": "THURSDAY", "timeSlots": [ { "id": 4, "startTimeOption": "19:00:00", "endTimeOption": "21:00:00" } ] }
+      ]
+    },
+    "guide2Coffeechats": {
+      "guide": { "id": 2, "nickname": "프론트가이드" },
+      "isOpened": true,
+      "title": "프론트엔드 커리어 상담",
+      "tags": [ { "id": 3, "hashTagName": "#프론트엔드" }, { "id": 4, "hashTagName": "#포트폴리오" } ],
+      "reviewScore": 4.3,
+      "reviewCount": 2,
+      "experiences": {
+        "groups": [
+          { "id": 3, "experienceTitle": "프론트 면접 경험" },
+          { "id": 4, "experienceTitle": "포트폴리오 리뷰" }
+        ]
+      },
+      "experienceDetail": { "id": 2, "who": "주니어 프론트엔드" }
+    },
+    "guide2PendingReservationsForMe": [
+      { "reservationId": 6, "status": "PENDING" },
+      { "reservationId": 7, "status": "PENDING" }
+    ],
+    "guide2Reviews": [
+      { "id": 8, "reservationId": 6, "comment": "프론트 면접 팁이 유익했어요.", "starReview": 4.5 },
+      { "id": 9, "reservationId": 7, "comment": "포트폴리오 피드백 좋았어요.", "starReview": 4.0 }
+    ]
+  }
+}
+

--- a/src/main/java/coffeandcommit/crema/domain/reservation/entity/Survey.java
+++ b/src/main/java/coffeandcommit/crema/domain/reservation/entity/Survey.java
@@ -21,7 +21,8 @@ public class Survey extends BaseEntity{
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false, length = 2048)
+    // 명시적으로 컬럼명을 지정해 init.sql과 일치시킵니다.
+    @Column(name = "file_upload_url", nullable = false, length = 2048)
     private String fileUploadURL;
 
     @Column(nullable = true)

--- a/src/main/resources/init.sql
+++ b/src/main/resources/init.sql
@@ -1,0 +1,203 @@
+-- ===========================
+-- Crema 프로젝트 초기 데이터 삽입 SQL
+-- ===========================
+
+SET FOREIGN_KEY_CHECKS = 0;
+
+TRUNCATE TABLE notification;
+TRUNCATE TABLE candidate;
+TRUNCATE TABLE meeting_room;
+TRUNCATE TABLE hash_tag;
+TRUNCATE TABLE experience_detail;
+TRUNCATE TABLE experience_group;
+TRUNCATE TABLE review_experience;
+TRUNCATE TABLE review;
+TRUNCATE TABLE time_unit;
+TRUNCATE TABLE reservation;
+TRUNCATE TABLE survey_file;
+TRUNCATE TABLE survey;
+TRUNCATE TABLE time_slot;
+TRUNCATE TABLE guide_schedule;
+TRUNCATE TABLE guide_chat_topic;
+TRUNCATE TABLE guide_job_field;
+TRUNCATE TABLE guide;
+TRUNCATE TABLE member_chat_topic;
+TRUNCATE TABLE chat_topic;
+TRUNCATE TABLE member_job_field;
+TRUNCATE TABLE member;
+
+-- SET FOREIGN_KEY_CHECKS = 1; -- 데이터 입력 후 재활성화 (파일 말미)
+
+-- Member: phone_number 컬럼은 존재하지 않음. provider/provider_id는 존재.
+INSERT INTO member (id, nickname, role, point, profile_image_url, description, provider, provider_id, is_deleted, created_at) VALUES
+  ('MBR00001', '홍길동', 'ROOKIE', 100, 'https://cdn.example.com/profile1.png', '백엔드 지망생입니다.', 'GOOGLE', 'google_123', false, NOW()),
+  ('MBR00002', '김선배', 'GUIDE', 200, 'https://cdn.example.com/profile2.png', '현직 백엔드 개발자입니다.', 'KAKAO', 'kakao_456', false, NOW()),
+  ('MBR00003', '프론트가이드', 'GUIDE', 150, 'https://cdn.example.com/profile3.png', '프론트엔드 개발자입니다.', 'GOOGLE', 'google_789', false, NOW());
+
+-- ===========================
+-- JobNameType ENUM 값에 맞게 입력 (예: IT_DEVELOPMENT_DATA 등)
+INSERT INTO member_job_field (id, member_id, job_name) VALUES
+  (1, 'MBR00001', 'IT_DEVELOPMENT_DATA'),
+  (2, 'MBR00002', 'RESEARCH_RND'),
+  (3, 'MBR00003', 'IT_DEVELOPMENT_DATA');
+
+-- ===========================
+-- TopicNameType ENUM 값 사용 (CAREER 는 없음 → JOB_CHANGE 사용)
+INSERT INTO chat_topic (id, topic_name) VALUES
+  (1, 'INTERVIEW'),
+  (2, 'RESUME'),
+  (3, 'JOB_CHANGE');
+
+-- ===========================
+-- 컬럼명: chat_topic_id (topic_id 아님)
+INSERT INTO member_chat_topic (id, member_id, chat_topic_id) VALUES
+  (1, 'MBR00001', 1),
+  (2, 'MBR00001', 2),
+  (3, 'MBR00002', 3);
+
+-- ===========================
+-- 필수: title, (선택) certification_image_url, job_position; working_period는 선택
+INSERT INTO guide (id, member_id, chat_description, is_opened, title, certification_image_url, approved_date, working_start, working_end, job_position, company_name, is_company_name_public, is_current)
+VALUES (1, 'MBR00002', '커피챗으로 면접 준비 도와드립니다.', true, '백엔드 면접/이직 상담', 'https://cdn.example.com/cert1.png', NOW(), '2020-01-01', NULL, 'Backend Engineer', '네이버', true, true),
+       (2, 'MBR00003', '프론트엔드 커리어/포트폴리오 상담합니다.', true, '프론트엔드 커리어 상담', 'https://cdn.example.com/cert2.png', NOW(), '2019-03-01', NULL, 'Frontend Engineer', '카카오', true, true);
+
+-- ===========================
+-- GuideJobField 는 Guide 당 1개 (OneToOne, guide_id unique). ENUM 값 맞춤
+INSERT INTO guide_job_field (id, guide_id, job_name) VALUES
+  (1, 1, 'IT_DEVELOPMENT_DATA'),
+  (2, 2, 'IT_DEVELOPMENT_DATA');
+
+-- ===========================
+-- 컬럼명: chat_topic_id
+INSERT INTO guide_chat_topic (id, guide_id, chat_topic_id) VALUES
+  (1, 1, 1),
+  (2, 1, 3),
+  (3, 2, 1),
+  (4, 2, 2);
+
+-- ===========================
+-- Guide Schedule
+-- ===========================
+INSERT INTO guide_schedule (id, guide_id, day_of_week) VALUES
+                                                           (1, 1, 'MONDAY'),
+                                                           (2, 1, 'WEDNESDAY'),
+                                                           (3, 2, 'TUESDAY'),
+                                                           (4, 2, 'THURSDAY');
+
+-- ===========================
+-- Time Slot
+-- ===========================
+INSERT INTO time_slot (id, schedule_id, start_time_option, end_time_option) VALUES
+                                                                                (1, 1, '09:00:00', '12:00:00'),
+                                                                                (2, 2, '14:00:00', '18:00:00'),
+                                                                                (3, 3, '10:00:00', '12:00:00'),
+                                                                                (4, 4, '19:00:00', '21:00:00');
+
+-- 필수: file_upload_url, preferred_date. updated_at 컬럼은 없고 modified_at 임
+INSERT INTO survey (id, file_upload_url, message_to_guide, preferred_date, created_at, modified_at) VALUES
+  (1, 'https://cdn.example.com/survey1-root.pdf', '면접 준비 조언 부탁드립니다.', '2025-09-15 15:00:00', NOW(), NOW()),
+  (2, 'https://cdn.example.com/survey2-root.pdf', '자소서 피드백 받고 싶습니다.', '2025-09-20 19:00:00', NOW(), NOW()),
+  (3, 'https://cdn.example.com/survey3-root.pdf', '프로젝트 코드 리뷰 받고 싶어요.', '2025-09-22 20:00:00', NOW(), NOW()),
+  (4, 'https://cdn.example.com/survey4-root.pdf', '커리어 전환 조언 부탁드립니다.', '2025-09-25 21:00:00', NOW(), NOW()),
+  (5, 'https://cdn.example.com/survey5-root.pdf', '포트폴리오 피드백 부탁드립니다.', '2025-09-28 10:00:00', NOW(), NOW()),
+  (6, 'https://cdn.example.com/survey6-root.pdf', '프론트 면접 상담 부탁드립니다.', '2025-09-29 10:00:00', NOW(), NOW()),
+  (7, 'https://cdn.example.com/survey7-root.pdf', '리액트 포트폴리오 문의드립니다.', '2025-09-30 14:00:00', NOW(), NOW());
+
+
+-- 컬럼명: file_Key (@Column 명시)
+INSERT INTO survey_file (id, survey_id, file_Key) VALUES
+  (1, 1, 'survey/1/file1.pdf'),
+  (2, 2, 'survey/2/file1.pdf'),
+  (3, 3, 'survey/3/file1.pdf'),
+  (4, 4, 'survey/4/file1.pdf'),
+  (5, 5, 'survey/5/file1.pdf'),
+  (6, 6, 'survey/6/file1.pdf'),
+  (7, 7, 'survey/7/file1.pdf');
+
+-- ===========================
+-- 통계 검증을 위해 1번 예약은 COMPLETED 로 설정
+INSERT INTO reservation (id, guide_id, member_id, survey_id, matching_time, status, reserved_at) VALUES
+  (1, 1, 'MBR00001', 1, '2025-09-15 15:00:00', 'COMPLETED', NOW()),
+  (2, 1, 'MBR00001', 2, '2025-09-20 19:00:00', 'PENDING', NOW()),
+  (3, 1, 'MBR00001', 3, '2025-09-22 20:00:00', 'COMPLETED', NOW()),
+  (4, 1, 'MBR00001', 4, '2025-09-25 21:00:00', 'COMPLETED', NOW()),
+  (5, 1, 'MBR00001', 5, '2025-09-28 10:00:00', 'COMPLETED', NOW()),
+  (6, 2, 'MBR00001', 6, '2025-09-29 10:00:00', 'PENDING', NOW()),
+  (7, 2, 'MBR00001', 7, '2025-09-30 14:00:00', 'PENDING', NOW());
+
+-- ===========================
+-- 컬럼명: time_type (ENUM), price 컬럼 없음 (TimeType 에 포함)
+INSERT INTO time_unit (id, reservation_id, time_type) VALUES
+  (1, 1, 'MINUTE_30'),
+  (2, 2, 'MINUTE_60'),
+  (3, 3, 'MINUTE_30'),
+  (4, 4, 'MINUTE_60'),
+  (5, 5, 'MINUTE_30'),
+  (6, 6, 'MINUTE_30'),
+  (7, 7, 'MINUTE_60');
+
+-- ===========================
+-- 컬럼명: comment, star_review 는 소수(2,1)
+INSERT INTO review (id, reservation_id, comment, star_review) VALUES
+  (1, 1, '면접 팁이 정말 유익했습니다!', 4.5),
+  (2, 3, '프로젝트 코드 리뷰가 큰 도움이 됐어요.', 5.0),
+  (3, 4, '커리어 전환 방향성을 잡을 수 있었어요.', 4.0),
+  (4, 5, '포트폴리오 개선 포인트를 알게 되었어요.', 3.5),
+  (8, 6, '프론트 면접 팁이 유익했어요.', 4.5),
+  (9, 7, '포트폴리오 피드백 좋았어요.', 4.0);
+
+-- ===========================
+-- Experience Group
+-- ===========================
+INSERT INTO experience_group (id, guide_id, guide_chat_topic_id, experience_title, experience_content) VALUES
+                                                                                                           (1, 1, 1, '면접 경험', '삼성전자 면접 합격 경험'),
+                                                                                                           (2, 1, 2, '이직 경험', '스타트업 → 대기업 전환기 이야기'),
+                                                                                                           (3, 2, 3, '프론트 면접 경험', '카카오 면접 합격 경험'),
+                                                                                                           (4, 2, 4, '포트폴리오 리뷰', '리액트 포트폴리오 개선 사례');
+
+-- ===========================
+-- Experience Detail
+-- ===========================
+INSERT INTO experience_detail (id, guide_id, who, solution, how) VALUES
+  (1, 1, '신입 지원자', '코딩테스트 대비', '스터디 그룹 운영'),
+  (2, 2, '주니어 프론트엔드', '포트폴리오 개선', '컴포넌트 구조 리팩토링');
+
+-- ===========================
+-- 좋아요(is_thumbs_up)도 함께 설정
+INSERT INTO review_experience (id, review_id, experience_group_id, is_thumbs_up) VALUES
+  (1, 1, 1, true),
+  (2, 2, 1, true),
+  (3, 3, 2, true),
+  (4, 4, 2, false),
+  (5, 8, 3, true),
+  (6, 9, 4, true);
+
+-- ===========================
+-- Hash Tag
+-- ===========================
+INSERT INTO hash_tag (id, guide_id, hash_tag_name) VALUES
+                                                       (1, 1, '#백엔드'),
+                                                       (2, 1, '#면접준비'),
+                                                       (3, 2, '#프론트엔드'),
+                                                       (4, 2, '#포트폴리오');
+
+-- ===========================
+-- Meeting Room
+-- ===========================
+INSERT INTO meeting_room (id, reservation_id, start_time, end_time, room_url) VALUES
+    (1, 1, '2025-09-15 15:00:00', '2025-09-15 15:30:00', 'https://meet.example.com/room1');
+
+-- ===========================
+-- 컬럼명: time_id (TimeSlot FK)
+INSERT INTO candidate (id, reservation_id, time_id, priority, candidate_date) VALUES
+  (1, 1, 1, 1, '2025-09-14 10:00:00'),
+  (2, 2, 2, 2, '2025-09-19 15:00:00');
+
+-- ===========================
+-- 컬럼: type 없음
+INSERT INTO notification (id, member_id, reservation_id, message, is_read, created_at) VALUES
+  (1, 'MBR00001', 1, '예약이 확정되었습니다.', false, NOW()),
+  (2, 'MBR00002', 1, '새로운 후기가 등록되었습니다.', false, NOW());
+
+-- FK 재활성화
+SET FOREIGN_KEY_CHECKS = 1;


### PR DESCRIPTION
# 🚀 What’s this PR about?

- 테스트 시 사전자료 조회 불가능 문제해결

# 🛠️ What’s been done?

- 서비스 엔티티 칼럼 명 수정

# 🧪 Testing Details
<img width="478" height="655" alt="image" src="https://github.com/user-attachments/assets/54d51d81-5f4c-4d5a-ac2b-fef40529ff2c" />

# 👀 Checkpoints for Reviewers



# 📚 References & Resources



# 🎯 Related Issues
close#104 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신규 기능
  - 사용자에게 직접 노출되는 신규 기능 변경사항이 없습니다.
- 버그 수정
  - 설문 엔티티의 파일 업로드 URL 필드에 대한 데이터베이스 컬럼 매핑을 명시적으로 지정하여 매핑 일관성 향상.
- 작업(Chores)
  - 데이터베이스 초기화 스크립트 추가: 다수 테이블 초기화 및 광범위한 샘플 데이터 삽입 포함.
  - 테스트/개발용 목업 데이터 파일 추가: 엔드투엔드 및 API 시나리오용 포괄적 시드 데이터 제공.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->