### PR TITLE
프론트 요청 시 string 입력 가능 구현

### DIFF
--- a/mock/init-dummy.json
+++ b/mock/init-dummy.json
@@ -203,7 +203,7 @@
           "profileImageUrl": "https://cdn.example.com/profile2.png",
           "title": "백엔드 면접/이직 상담",
           "workingPeriod": null,
-          "jobField": { "guideId": 1, "jobName": "IT_DEVELOPMENT_DATA" },
+          "jobField": { "guideId": 1, "jobName": "IT_DEVELOPMENT_DATA", "jobNameDescription": "IT 개발/데이터" },
           "hashTags": [
             { "id": 1, "guideId": 1, "hashTagName": "#백엔드" },
             { "id": 2, "guideId": 1, "hashTagName": "#면접준비" }
@@ -216,7 +216,7 @@
           "profileImageUrl": "https://cdn.example.com/profile3.png",
           "title": "프론트엔드 커리어 상담",
           "workingPeriod": null,
-          "jobField": { "guideId": 2, "jobName": "IT_DEVELOPMENT_DATA" },
+          "jobField": { "guideId": 2, "jobName": "IT_DEVELOPMENT_DATA", "jobNameDescription": "IT 개발/데이터" },
           "hashTags": [
             { "id": 3, "guideId": 2, "hashTagName": "#프론트엔드" },
             { "id": 4, "guideId": 2, "hashTagName": "#포트폴리오" }
@@ -226,8 +226,8 @@
       ]
     },
     "guide2ChatTopics": [
-      { "id": 3, "guideId": 2, "topic": { "topicName": "INTERVIEW" } },
-      { "id": 4, "guideId": 2, "topic": { "topicName": "RESUME" } }
+      { "id": 3, "guideId": 2, "topic": { "topicName": "INTERVIEW", "description": "면접" } },
+      { "id": 4, "guideId": 2, "topic": { "topicName": "RESUME", "description": "이력서" } }
     ],
     "guide2Schedules": {
       "guideId": 2,

--- a/src/main/java/coffeandcommit/crema/domain/globalTag/dto/TopicDTO.java
+++ b/src/main/java/coffeandcommit/crema/domain/globalTag/dto/TopicDTO.java
@@ -12,10 +12,13 @@ public class TopicDTO {
 
     @JsonFormat(shape = JsonFormat.Shape.STRING)
     private TopicNameType topicName;
+    private String description; // 프론트 표시용 설명 문자열
 
     public static TopicDTO from(TopicNameType topicName) {
+        TopicNameType type = (topicName != null) ? topicName : TopicNameType.UNDEFINED;
         return TopicDTO.builder()
-                .topicName(topicName != null ? topicName : TopicNameType.UNDEFINED)
+                .topicName(type)
+                .description(type.getDescription())
                 .build();
     }
 }

--- a/src/main/java/coffeandcommit/crema/domain/guide/controller/GuideController.java
+++ b/src/main/java/coffeandcommit/crema/domain/guide/controller/GuideController.java
@@ -1,5 +1,7 @@
 package coffeandcommit.crema.domain.guide.controller;
 
+import coffeandcommit.crema.domain.globalTag.enums.JobNameType;
+import coffeandcommit.crema.domain.globalTag.enums.TopicNameType;
 import coffeandcommit.crema.domain.guide.dto.response.*;
 import coffeandcommit.crema.domain.guide.service.GuideService;
 import coffeandcommit.crema.global.auth.service.CustomUserDetails;
@@ -277,8 +279,8 @@ public class GuideController {
 
     @GetMapping
     public ResponseEntity<Response<Page<GuideListResponseDTO>>> getGuides(
-            @RequestParam(required = false) List<Long> jobFieldIds,
-            @RequestParam(required = false) List<Long> chatTopicIds,
+            @RequestParam(required = false) List<JobNameType> jobNames,
+            @RequestParam(required = false) List<TopicNameType> chatTopicNames,
             @RequestParam(required = false) String keyword,
             @RequestParam(defaultValue = "0") @Min(0) int page,
             @RequestParam(defaultValue = "20") @Min(1) @Max(100) int size,
@@ -296,7 +298,7 @@ public class GuideController {
         Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "modifiedAt"));
 
         Page<GuideListResponseDTO> guides =
-                guideService.getGuides(jobFieldIds, chatTopicIds, keyword, pageable, loginMemberId, sort);
+                guideService.getGuides(jobNames, chatTopicNames, keyword, pageable, loginMemberId, sort);
 
         Response<Page<GuideListResponseDTO>> response = Response.<Page<GuideListResponseDTO>>builder()
                 .message("가이드 목록 조회 성공")

--- a/src/main/java/coffeandcommit/crema/domain/guide/dto/response/GuideJobFieldResponseDTO.java
+++ b/src/main/java/coffeandcommit/crema/domain/guide/dto/response/GuideJobFieldResponseDTO.java
@@ -14,16 +14,18 @@ import lombok.NoArgsConstructor;
 public class GuideJobFieldResponseDTO {
 
     private Long guideId;
-    private JobNameType jobName;
+    private JobNameType jobName; // 기존 호환 유지 (enum)
+    private String jobNameDescription; // 프론트 표시용 설명 문자열
 
     public static GuideJobFieldResponseDTO from(GuideJobField guideJobField) {
+        JobNameType type = guideJobField.getJobName() != null
+                ? guideJobField.getJobName()
+                : JobNameType.UNDEFINED;
+
         return GuideJobFieldResponseDTO.builder()
                 .guideId(guideJobField.getGuide().getId())
-                .jobName(
-                        guideJobField.getJobName() != null
-                                ? guideJobField.getJobName()
-                                : JobNameType.UNDEFINED
-                )
+                .jobName(type)
+                .jobNameDescription(type.getDescription())
                 .build();
     }
 

--- a/src/main/java/coffeandcommit/crema/domain/guide/repository/GuideRepository.java
+++ b/src/main/java/coffeandcommit/crema/domain/guide/repository/GuideRepository.java
@@ -7,6 +7,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import coffeandcommit.crema.domain.globalTag.enums.JobNameType;
+import coffeandcommit.crema.domain.globalTag.enums.TopicNameType;
 
 import java.util.List;
 import java.util.Optional;
@@ -22,8 +24,8 @@ public interface GuideRepository extends JpaRepository<Guide, Long> {
      * 조건에 따라 필터링된 가이드를 페이지 단위로 반환합니다.
      * 영업 중(isOpened = true)인 가이드만 조회됩니다.
      *
-     * @param jobFieldIds 직무분야 ID 목록
-     * @param chatTopicIds 커피챗 주제 ID 목록
+     * @param jobNames 직무분야 이름 목록 (ENUM)
+     * @param chatTopicNames 커피챗 주제 이름 목록 (ENUM)
      * @param keyword 검색 키워드 (title, hashTagName)
      * @param pageable 페이징 정보
      * @return 필터링된 가이드 목록
@@ -36,8 +38,8 @@ public interface GuideRepository extends JpaRepository<Guide, Long> {
             LEFT JOIN g.guideChatTopics gct
             LEFT JOIN g.hashTags ht
             WHERE g.isOpened = true
-              AND (:jobFieldIds IS NULL OR gjf.id IN :jobFieldIds)
-              AND (:chatTopicIds IS NULL OR gct.chatTopic.id IN :chatTopicIds)
+              AND (:jobNames IS NULL OR gjf.jobName IN :jobNames)
+              AND (:chatTopicNames IS NULL OR gct.chatTopic.topicName IN :chatTopicNames)
               AND (:keyword IS NULL
                    OR LOWER(g.title) LIKE LOWER(CONCAT('%', :keyword, '%'))
                    OR LOWER(ht.hashTagName) LIKE LOWER(CONCAT('%', :keyword, '%')))
@@ -49,16 +51,16 @@ public interface GuideRepository extends JpaRepository<Guide, Long> {
             LEFT JOIN g.guideChatTopics gct
             LEFT JOIN g.hashTags ht
             WHERE g.isOpened = true
-              AND (:jobFieldIds IS NULL OR gjf.id IN :jobFieldIds)
-              AND (:chatTopicIds IS NULL OR gct.chatTopic.id IN :chatTopicIds)
+              AND (:jobNames IS NULL OR gjf.jobName IN :jobNames)
+              AND (:chatTopicNames IS NULL OR gct.chatTopic.topicName IN :chatTopicNames)
               AND (:keyword IS NULL
                    OR LOWER(g.title) LIKE LOWER(CONCAT('%', :keyword, '%'))
                    OR LOWER(ht.hashTagName) LIKE LOWER(CONCAT('%', :keyword, '%')))
             """
     )
     Page<Guide> findBySearchConditions(
-            @Param("jobFieldIds") List<Long> jobFieldIds,
-            @Param("chatTopicIds") List<Long> chatTopicIds,
+            @Param("jobNames") List<JobNameType> jobNames,
+            @Param("chatTopicNames") List<TopicNameType> chatTopicNames,
             @Param("keyword") String keyword,
             Pageable pageable
     );

--- a/src/main/java/coffeandcommit/crema/domain/guide/service/GuideService.java
+++ b/src/main/java/coffeandcommit/crema/domain/guide/service/GuideService.java
@@ -374,16 +374,27 @@ public class GuideService {
         );
     }
 
-    /* 가이드 목록 조회 */
+    /* 가이드 목록 조회 (enum 기반 필터) */
     @Transactional(readOnly = true)
-    public Page<GuideListResponseDTO> getGuides(List<Long> jobFieldIds, List<Long> chatTopicIds, String keyword, Pageable pageable, String loginMemberId, String sort) {
+    public Page<GuideListResponseDTO> getGuides(
+            List<coffeandcommit.crema.domain.globalTag.enums.JobNameType> jobNames,
+            List<coffeandcommit.crema.domain.globalTag.enums.TopicNameType> chatTopicNames,
+            String keyword,
+            Pageable pageable,
+            String loginMemberId,
+            String sort
+    ) {
 
         boolean isPopular = "popular".equalsIgnoreCase(sort);
 
+        // 빈 리스트 방어: JPA IN () 오류 방지용
+        jobNames = (jobNames != null && jobNames.isEmpty()) ? null : jobNames;
+        chatTopicNames = (chatTopicNames != null && chatTopicNames.isEmpty()) ? null : chatTopicNames;
+
         // 1. popular는 전체 데이터 조회 (unpaged), latest는 DB에서 페이징
         Page<Guide> guides = isPopular
-                ? guideRepository.findBySearchConditions(jobFieldIds, chatTopicIds, keyword, Pageable.unpaged())
-                : guideRepository.findBySearchConditions(jobFieldIds, chatTopicIds, keyword, pageable);
+                ? guideRepository.findBySearchConditions(jobNames, chatTopicNames, keyword, Pageable.unpaged())
+                : guideRepository.findBySearchConditions(jobNames, chatTopicNames, keyword, pageable);
 
         // 2. DTO 변환
         List<GuideListResponseDTO> dtoList = guides.stream()

--- a/src/main/java/coffeandcommit/crema/domain/reservation/dto/response/MemberChatTopicResponseDTO.java
+++ b/src/main/java/coffeandcommit/crema/domain/reservation/dto/response/MemberChatTopicResponseDTO.java
@@ -17,9 +17,7 @@ public class MemberChatTopicResponseDTO {
     private TopicDTO topic;   // 글로벌 태그 DTO 재사용
 
     public static MemberChatTopicResponseDTO from(MemberChatTopic memberChatTopic) {
-        TopicDTO topic = TopicDTO.builder()
-                .topicName(memberChatTopic.getChatTopic().getTopicName())
-                .build();
+        TopicDTO topic = TopicDTO.from(memberChatTopic.getChatTopic().getTopicName());
 
         return MemberChatTopicResponseDTO.builder()
                 .id(memberChatTopic.getId())

--- a/src/test/java/coffeandcommit/crema/domain/guide/service/GuideServiceTest.java
+++ b/src/test/java/coffeandcommit/crema/domain/guide/service/GuideServiceTest.java
@@ -43,6 +43,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
+import static coffeandcommit.crema.domain.globalTag.enums.JobNameType.DESIGN;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
@@ -128,7 +129,7 @@ public class GuideServiceTest {
         guideJobField = GuideJobField.builder()
                 .id(1L)
                 .guide(guide1)
-                .jobName(JobNameType.DESIGN)
+                .jobName(DESIGN)
                 .build();
 
         chatTopic1 = ChatTopic.builder()
@@ -219,7 +220,7 @@ public class GuideServiceTest {
 
         assertNotNull(result);
         assertEquals(1L, result.getGuideId());
-        assertEquals(JobNameType.DESIGN, result.getJobName());
+        assertEquals(DESIGN, result.getJobName());
 
         verify(guideRepository).findById(1L);
         verify(guideJobFieldRepository).findByGuide(guide1);
@@ -1063,8 +1064,8 @@ public class GuideServiceTest {
     @DisplayName("가이드 목록 조회 - 성공")
     void getGuides_Success() {
         // 테스트 데이터 준비
-        List<Long> jobFieldIds = List.of(1L);
-        List<Long> chatTopicIds = List.of(1L, 2L);
+        List<JobNameType> jobNames = List.of(DESIGN);
+        List<TopicNameType> chatTopicNames = List.of(TopicNameType.INTERVIEW, TopicNameType.RESUME);
         String keyword = "Java";
         Pageable pageable = Pageable.unpaged();
         String loginMemberId = "member1";
@@ -1082,7 +1083,7 @@ public class GuideServiceTest {
         Page<Guide> guidePage = new PageImpl<>(List.of(guide1));
 
         // Mock 설정
-        when(guideRepository.findBySearchConditions(jobFieldIds, chatTopicIds, keyword, pageable))
+        when(guideRepository.findBySearchConditions(jobNames, chatTopicNames, keyword, pageable))
                 .thenReturn(guidePage);
         when(reservationRepository.countByGuideAndStatus(guide1, Status.COMPLETED)).thenReturn(5L);
         when(reviewRepository.calculateAverageStarByGuide(guide1)).thenReturn(java.math.BigDecimal.valueOf(4.5));
@@ -1090,7 +1091,7 @@ public class GuideServiceTest {
         when(reviewExperienceRepository.countThumbsUpByGuide(guide1)).thenReturn(7L);
 
         // 테스트 실행
-        Page<GuideListResponseDTO> result = guideService.getGuides(jobFieldIds, chatTopicIds, keyword, pageable, loginMemberId, sort);
+        Page<GuideListResponseDTO> result = guideService.getGuides(jobNames, chatTopicNames, keyword, pageable, loginMemberId, sort);
 
         // 검증
         assertNotNull(result);
@@ -1100,7 +1101,7 @@ public class GuideServiceTest {
         GuideListResponseDTO dto = result.getContent().get(0);
         assertEquals(guide1.getId(), dto.getGuideId());
         assertEquals(guide1.getTitle(), dto.getTitle());
-        assertEquals(JobNameType.DESIGN, dto.getJobField().getJobName());
+        assertEquals(DESIGN, dto.getJobField().getJobName());
         assertEquals(2, dto.getHashTags().size());
         assertEquals(5L, dto.getStats().getTotalCoffeeChats());
         assertEquals(4.5, dto.getStats().getAverageStar());
@@ -1108,7 +1109,7 @@ public class GuideServiceTest {
         assertEquals(7L, dto.getStats().getThumbsUpCount());
 
         // 메서드 호출 검증
-        verify(guideRepository).findBySearchConditions(jobFieldIds, chatTopicIds, keyword, pageable);
+        verify(guideRepository).findBySearchConditions(jobNames, chatTopicNames, keyword, pageable);
         verify(reservationRepository).countByGuideAndStatus(guide1, Status.COMPLETED);
         verify(reviewRepository).calculateAverageStarByGuide(guide1);
         verify(reviewRepository).countByGuide(guide1);
@@ -1119,8 +1120,8 @@ public class GuideServiceTest {
     @DisplayName("가이드 목록 조회 - 빈 결과")
     void getGuides_EmptyResult() {
         // 테스트 데이터 준비
-        List<Long> jobFieldIds = List.of(999L); // 존재하지 않는 ID
-        List<Long> chatTopicIds = null;
+        List<JobNameType> jobNames = List.of(DESIGN);
+        List<TopicNameType> chatTopicNames = null;
         String keyword = null;
         Pageable pageable = Pageable.unpaged();
         String loginMemberId = "member1";
@@ -1130,11 +1131,11 @@ public class GuideServiceTest {
         Page<Guide> emptyPage = new PageImpl<>(List.of());
 
         // Mock 설정
-        when(guideRepository.findBySearchConditions(jobFieldIds, chatTopicIds, keyword, pageable))
+        when(guideRepository.findBySearchConditions(jobNames, chatTopicNames, keyword, pageable))
                 .thenReturn(emptyPage);
 
         // 테스트 실행
-        Page<GuideListResponseDTO> result = guideService.getGuides(jobFieldIds, chatTopicIds, keyword, pageable, loginMemberId, sort);
+        Page<GuideListResponseDTO> result = guideService.getGuides(jobNames, chatTopicNames, keyword, pageable, loginMemberId, sort);
 
         // 검증
         assertNotNull(result);
@@ -1142,7 +1143,7 @@ public class GuideServiceTest {
         assertTrue(result.getContent().isEmpty());
 
         // 메서드 호출 검증
-        verify(guideRepository).findBySearchConditions(jobFieldIds, chatTopicIds, keyword, pageable);
+        verify(guideRepository).findBySearchConditions(jobNames, chatTopicNames, keyword, pageable);
         verifyNoInteractions(reservationRepository, reviewRepository, reviewExperienceRepository);
     }
 
@@ -1150,8 +1151,8 @@ public class GuideServiceTest {
     @DisplayName("가이드 목록 조회 - 인기순 정렬")
     void getGuides_SortByPopularity() {
         // 테스트 데이터 준비
-        List<Long> jobFieldIds = null;
-        List<Long> chatTopicIds = null;
+        List<JobNameType> jobNames = null;
+        List<TopicNameType> chatTopicNames = null;
         String keyword = null;
         Pageable pageable = Pageable.unpaged();
         String loginMemberId = "member1";
@@ -1189,7 +1190,7 @@ public class GuideServiceTest {
         Page<Guide> guidePage = new PageImpl<>(List.of(guide1, guide3));
 
         // Mock 설정
-        when(guideRepository.findBySearchConditions(jobFieldIds, chatTopicIds, keyword, pageable))
+        when(guideRepository.findBySearchConditions(jobNames, chatTopicNames, keyword, pageable))
                 .thenReturn(guidePage);
 
         // guide1 설정
@@ -1206,7 +1207,7 @@ public class GuideServiceTest {
 
         // 테스트 실행
         Page<GuideListResponseDTO> result = guideService.getGuides(
-                jobFieldIds, chatTopicIds, keyword, pageable, loginMemberId, sort);
+                jobNames, chatTopicNames, keyword, pageable, loginMemberId, sort);
 
         // 검증
         assertNotNull(result);
@@ -1224,7 +1225,7 @@ public class GuideServiceTest {
         assertEquals(10L, second.getStats().getTotalReviews());
 
         // 메서드 호출 검증
-        verify(guideRepository).findBySearchConditions(jobFieldIds, chatTopicIds, keyword, pageable);
+        verify(guideRepository).findBySearchConditions(jobNames, chatTopicNames, keyword, pageable);
     }
 
 }


### PR DESCRIPTION
# 🚀 What’s this PR about?

- 프론트 요청 시 string 입력

# 🛠️ What’s been done?

-프론트 요청시 id 값으로 전달 받지 않고 enum 값 그대로 요청 받는 로직으로 수정

# 🧪 Testing Details

<img width="723" height="707" alt="image" src="https://github.com/user-attachments/assets/ba5a1a08-ea0e-4fcd-9af3-903dbda4ec4d" />

# 👀 Checkpoints for Reviewers



# 📚 References & Resources



# 🎯 Related Issues
- close#108 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 가이드/토픽에 한글 설명이 추가되어 목록·필터에서 더 이해하기 쉬운 텍스트가 노출됩니다. 예: 직무 설명 “IT 개발/데이터”, 토픽 설명 “면접”, “이력서”. (모의 데이터에도 반영)
- Refactor
  - 가이드 조회 필터가 ID 기반에서 enum 이름 기반으로 변경되어 의미 있는 값으로 바로 검색할 수 있습니다.
  - 미인증 요청에 대해 401 응답을 명확히 반환하도록 인증 검증을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->