### PR TITLE
refactor enum request 방식 통일

### DIFF
--- a/src/main/java/coffeandcommit/crema/domain/globalTag/enums/JobNameType.java
+++ b/src/main/java/coffeandcommit/crema/domain/globalTag/enums/JobNameType.java
@@ -1,5 +1,6 @@
 package coffeandcommit.crema.domain.globalTag.enums;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -23,5 +24,24 @@ public enum JobNameType {
     @JsonValue
     public String getDescription() {
         return description;
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static JobNameType from(Object value) {
+        if (value == null) return null;
+        String text = String.valueOf(value).trim();
+        // 1) Enum 이름으로 매칭 (권장 입력값)
+        for (JobNameType type : values()) {
+            if (type.name().equalsIgnoreCase(text)) {
+                return type;
+            }
+        }
+        // 2) 한글 설명으로 매칭 (기존 클라이언트 호환)
+        for (JobNameType type : values()) {
+            if (type.getDescription().equals(text)) {
+                return type;
+            }
+        }
+        throw new IllegalArgumentException("사용 불가능한 JobNameType: " + text);
     }
 }

--- a/src/main/java/coffeandcommit/crema/domain/globalTag/enums/TopicNameType.java
+++ b/src/main/java/coffeandcommit/crema/domain/globalTag/enums/TopicNameType.java
@@ -1,5 +1,6 @@
 package coffeandcommit.crema.domain.globalTag.enums;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.ToString;
@@ -24,4 +25,21 @@ public enum TopicNameType {
     JOB_CHANGE("이직");
 
     private final String description;
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static TopicNameType from(Object value) {
+        if (value == null) return null;
+        String text = String.valueOf(value).trim();
+        for (TopicNameType t : values()) {
+            if (t.name().equalsIgnoreCase(text)) {
+                return t;
+            }
+        }
+        for (TopicNameType t : values()) {
+            if (t.getDescription().equals(text)) {
+                return t;
+            }
+        }
+        throw new IllegalArgumentException("사용 불가능한 TopicNameType: " + text);
+    }
 }

--- a/src/main/java/coffeandcommit/crema/domain/guide/dto/response/GuideJobFieldResponseDTO.java
+++ b/src/main/java/coffeandcommit/crema/domain/guide/dto/response/GuideJobFieldResponseDTO.java
@@ -14,7 +14,7 @@ import lombok.NoArgsConstructor;
 public class GuideJobFieldResponseDTO {
 
     private Long guideId;
-    private JobNameType jobName; // 기존 호환 유지 (enum)
+    private String jobName; // 응답은 영문 enum 이름으로 고정
     private String jobNameDescription; // 프론트 표시용 설명 문자열
 
     public static GuideJobFieldResponseDTO from(GuideJobField guideJobField) {
@@ -24,7 +24,7 @@ public class GuideJobFieldResponseDTO {
 
         return GuideJobFieldResponseDTO.builder()
                 .guideId(guideJobField.getGuide().getId())
-                .jobName(type)
+                .jobName(type.name())
                 .jobNameDescription(type.getDescription())
                 .build();
     }

--- a/src/main/java/coffeandcommit/crema/global/httpTest/GuideMeService.http
+++ b/src/main/java/coffeandcommit/crema/global/httpTest/GuideMeService.http
@@ -11,7 +11,7 @@ POST http://localhost:8080/api/test/auth/login
 Content-Type: application/json
 
 {
-  "nickname": "rookie_4926예제6f5d"
+  "nickname": "guide_d8dffb39"
 }
 
 ### 4. JWT 토큰으로 내 정보 조회 테스트 (3번 에서 받은 accessToken을 Bearer 뒤에 붙여넣기, 다른 도메인에서도 token 사용 가능한지 확인용)
@@ -23,5 +23,39 @@ DELETE http://localhost:8080/api/test/auth/cleanup
 
 
 ### 6. 가이드 본인 프로필 조회
-GET http://localhost:8080/api/guides/me
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJlM2FjYjcwZCIsInR5cGUiOiJhY2Nlc3MiLCJqdGkiOiJmNTI0YzIxMi1mYjM0LTRhMTUtYmFhYi0zMzA4ZjY5NjE5M2EiLCJpYXQiOjE3NTY1NjA1ODMsImV4cCI6MTc1NjU2MjM4M30.7aPhVRM3YPi8n81EqL6oJJrECysATkIp4tHCFi9yokf3cNONWAbIpW59rOLS7uPKIDEO2onrO3fowdsBIKPn7Q
+GET http://localhost:8080/api/guides
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiI0NTM2ZjBjYiIsInR5cGUiOiJhY2Nlc3MiLCJqdGkiOiI1YWU3OGUzNi0zN2ZjLTQ5ZjItYTZlYy0yOWRhNmIzOWZhNmIiLCJpYXQiOjE3NTc0Nzk5NjEsImV4cCI6MTc1NzQ4MTc2MX0.AmBGY6o2yWpgUBcwiqkDKkxoPbbNFRhdN086J_bpG93hMTrEP3Sxwk1g5DbuSYul50BNVIPYdNXiv64GmMuMmw
+
+### 가이드 조회 (jobFieldIds, keyword 쿼리 파라미터)
+GET http://localhost:8080/api/guides?jobFieldIds=PLANNING_STRATEGY
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIwZWU5OWZlNSIsInR5cGUiOiJhY2Nlc3MiLCJqdGkiOiI2YzZhNzM5NS1kMTgzLTRiZDktODdmZS0wZTEyMjYzN2EzYTciLCJpYXQiOjE3NTc0ODY0ODksImV4cCI6MTc1NzQ4ODI4OX0.ZVYx2ultSlpr_BmSmQFGBt3EU62Jk5qYQqvxqSeAlepWtMsnuOVl1_GHiGyfPxSm2a6CZvtXgSTAdavN3ARvoA
+
+### Guide 직무분야 등록
+POST http://localhost:8080/api/guides/me/job-field
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIwZWU5OWZlNSIsInR5cGUiOiJhY2Nlc3MiLCJqdGkiOiI2YzZhNzM5NS1kMTgzLTRiZDktODdmZS0wZTEyMjYzN2EzYTciLCJpYXQiOjE3NTc0ODY0ODksImV4cCI6MTc1NzQ4ODI4OX0.ZVYx2ultSlpr_BmSmQFGBt3EU62Jk5qYQqvxqSeAlepWtMsnuOVl1_GHiGyfPxSm2a6CZvtXgSTAdavN3ARvoA
+Content-Type: application/json
+
+{
+  "jobName": "PLANNING_STRATEGY"
+}
+
+### Guide 직무분야 등록
+POST http://localhost:8080/api/guides/me/job-field
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiI2ZGM5MTgyMyIsInR5cGUiOiJhY2Nlc3MiLCJqdGkiOiJhZjAyMTMzNC05ODQ1LTQ5NmUtOTFmNi1iNzhkZjg1ZGE5YjEiLCJpYXQiOjE3NTc0ODEzNjMsImV4cCI6MTc1NzQ4MzE2M30.epLXwOJQaDLUgWFx7WCkO4Gzo29-ZAcXdu2WqsEeR7Hcxuf92IBewK8t32KFhcc8-LsgzF5WZqjVlqCePN1_jg
+Content-Type: application/json
+
+{
+  "jobName": "PLANNING_STRATEGY"
+}
+
+### 📌 특정 가이드 채팅 주제 조회 (GuideChatTopicResponse[])
+POST http://localhost:8080/api/guides/me/chat-topics
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIwZWU5OWZlNSIsInR5cGUiOiJhY2Nlc3MiLCJqdGkiOiI2YzZhNzM5NS1kMTgzLTRiZDktODdmZS0wZTEyMjYzN2EzYTciLCJpYXQiOjE3NTc0ODY0ODksImV4cCI6MTc1NzQ4ODI4OX0.ZVYx2ultSlpr_BmSmQFGBt3EU62Jk5qYQqvxqSeAlepWtMsnuOVl1_GHiGyfPxSm2a6CZvtXgSTAdavN3ARvoA
+Content-Type: application/json
+
+{
+  "topics": [
+    { "topicName": "직무 전환" },
+    { "topicName": "COVER_LETTER" }
+  ]
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -103,3 +103,4 @@ management:
         bucket: jmeter-metrics
         token: my-super-secret-token
         org: my-org
+        enabled: false


### PR DESCRIPTION
# 🚀 What’s this PR about?

- enum request 방식 통일

# 🛠️ What’s been done?
- jobName, topicName 한글, 영어 enum으로 request 가능
- enum request 방식 통일
- jobname response에서 description 만 출력되는 경우 해결


# 🧪 Testing Details

<img width="366" height="646" alt="image" src="https://github.com/user-attachments/assets/6d8bc6ec-d6e7-422c-9e8a-517ff2ebec34" />


# 👀 Checkpoints for Reviewers


# 📚 References & Resources


# 🎯 Related Issues
- close#115 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 뉴 기능
  - 직무·토픽 입력을 이름 또는 설명(대소문자 무관)으로 받아들여 요청 호환성 향상.
  - 가이드 챗 토픽 등록 시 존재하지 않을 경우 자동 생성하여 등록 흐름 원활화.
  - 가이드 직무 필드 응답에서 jobName을 문자열로 반환하여 클라이언트 처리 단순화.

- 테스트
  - 가이드 조회·직무 등록·토픽 등록 등 HTTP 시나리오와 예시 갱신.

- 작업(Chores)
  - Influx 메트릭 내보내기 사용 여부 설정 플래그 추가(기본 비활성화).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->