### PR TITLE
refactor -테스트 코드 변경

### DIFF
--- a/src/test/java/coffeandcommit/crema/domain/guide/service/GuideMeServiceTest.java
+++ b/src/test/java/coffeandcommit/crema/domain/guide/service/GuideMeServiceTest.java
@@ -211,7 +211,9 @@ public class GuideMeServiceTest {
 
         assertNotNull(result);
         assertEquals(guide.getId(), result.getGuideId());
-        assertEquals(JobNameType.IT_DEVELOPMENT_DATA, result.getJobName());
+        // 응답 스펙 변경 반영: jobName은 영문 enum 이름(String), description은 한글
+        assertEquals(JobNameType.IT_DEVELOPMENT_DATA.name(), result.getJobName());
+        assertEquals(JobNameType.IT_DEVELOPMENT_DATA.getDescription(), result.getJobNameDescription());
 
         verify(guideRepository).findByMember_Id(memberId);
         verify(guideJobFieldRepository).findByGuide(guide);
@@ -240,7 +242,9 @@ public class GuideMeServiceTest {
 
         assertNotNull(result);
         assertEquals(guide.getId(), result.getGuideId());
-        assertEquals(JobNameType.MARKETING_PR, result.getJobName());
+        // 응답 스펙 변경: jobName은 영문 enum 이름(String), jobNameDescription은 한글 설명
+        assertEquals(JobNameType.MARKETING_PR.name(), result.getJobName());
+        assertEquals(JobNameType.MARKETING_PR.getDescription(), result.getJobNameDescription());
 
         verify(guideRepository).findByMember_Id(memberId);
         verify(guideJobFieldRepository).findByGuide(guide);
@@ -423,11 +427,11 @@ public class GuideMeServiceTest {
     }
 
     @Test
-    @DisplayName("registerChatTopics 유효하지 않은 주제 테스트")
+    @DisplayName("registerChatTopics 유효하지 않은 주제 테스트 - null 값")
     void registerChatTopics_InvalidTopic() {
-        // 요청 DTO 생성
+        // 요청 DTO 생성: topicName null → INVALID_TOPIC
         TopicDTO topicDTO = TopicDTO.builder()
-                .topicName(TopicNameType.CAREER_CHANGE)
+                .topicName(null)
                 .build();
 
         GuideChatTopicRequestDTO requestDTO = GuideChatTopicRequestDTO.builder()
@@ -437,8 +441,6 @@ public class GuideMeServiceTest {
         // Mock 설정
         when(guideRepository.findByMember_Id(memberId)).thenReturn(Optional.of(guide));
         when(guideChatTopicRepository.countByGuide(guide)).thenReturn(0L);
-        when(chatTopicRepository.findByTopicName(TopicNameType.CAREER_CHANGE))
-                .thenReturn(Optional.empty());
 
         // 테스트 실행 및 검증
         BaseException exception = assertThrows(BaseException.class, () ->
@@ -448,7 +450,8 @@ public class GuideMeServiceTest {
         assertEquals(ErrorStatus.INVALID_TOPIC, exception.getErrorCode());
         verify(guideRepository).findByMember_Id(memberId);
         verify(guideChatTopicRepository).countByGuide(guide);
-        verify(chatTopicRepository).findByTopicName(TopicNameType.CAREER_CHANGE);
+        // chatTopicRepository는 호출되지 않아야 함
+        verify(chatTopicRepository, never()).findByTopicName(any());
         verify(guideChatTopicRepository, never()).existsByGuideAndChatTopic(any(), any());
         verify(guideChatTopicRepository, never()).save(any());
         verify(guideChatTopicRepository, never()).findAllByGuideWithJoin(any());

--- a/src/test/java/coffeandcommit/crema/domain/guide/service/GuideServiceTest.java
+++ b/src/test/java/coffeandcommit/crema/domain/guide/service/GuideServiceTest.java
@@ -220,7 +220,9 @@ public class GuideServiceTest {
 
         assertNotNull(result);
         assertEquals(1L, result.getGuideId());
-        assertEquals(DESIGN, result.getJobName());
+        // 응답 스펙 변경 반영: jobName은 영문 enum 이름(String), description은 한글
+        assertEquals(DESIGN.name(), result.getJobName());
+        assertEquals(DESIGN.getDescription(), result.getJobNameDescription());
 
         verify(guideRepository).findById(1L);
         verify(guideJobFieldRepository).findByGuide(guide1);
@@ -316,7 +318,8 @@ public class GuideServiceTest {
 
         assertNotNull(result);
         assertEquals(2L, result.getGuideId());
-        assertEquals(JobNameType.MARKETING_PR, result.getJobName());
+        assertEquals(JobNameType.MARKETING_PR.name(), result.getJobName());
+        assertEquals(JobNameType.MARKETING_PR.getDescription(), result.getJobNameDescription());
 
         verify(guideRepository).findById(2L);
         verify(guideJobFieldRepository).findByGuide(guide2);
@@ -1101,7 +1104,9 @@ public class GuideServiceTest {
         GuideListResponseDTO dto = result.getContent().get(0);
         assertEquals(guide1.getId(), dto.getGuideId());
         assertEquals(guide1.getTitle(), dto.getTitle());
-        assertEquals(DESIGN, dto.getJobField().getJobName());
+        // 응답 스펙 변경 반영: jobName은 String 영문 코드, description은 한글
+        assertEquals(DESIGN.name(), dto.getJobField().getJobName());
+        assertEquals(DESIGN.getDescription(), dto.getJobField().getJobNameDescription());
         assertEquals(2, dto.getHashTags().size());
         assertEquals(5L, dto.getStats().getTotalCoffeeChats());
         assertEquals(4.5, dto.getStats().getAverageStar());


### PR DESCRIPTION
# 🚀 What’s this PR about?

-  테스트 코드 변경

# 🛠️ What’s been done?

-  jobname, chattopic 타입 통일 관련 테스트 코드 변경

# 🧪 Testing Details

- getGuideJobField_Success
 - 변경: jobName → DESIGN.name(), jobNameDescription → DESIGN.getDescription()
- getGuideJobField_OwnerCanAccessPrivateGuide
 - 변경: jobName → MARKETING_PR.name(), jobNameDescription → MARKETING_PR.getDescription()
- getGuides_Success
 - 변경: dto.getJobField().getJobName() → DESIGN.name()
 - 추가: dto.getJobField().getJobNameDescription() → DESIGN.getDescription()
- registerGuideJobField_CreateNewJobField_Success
  - 변경: jobName → IT_DEVELOPMENT_DATA.name(), jobNameDescription → IT_DEVELOPMENT_DATA.getDescription()
- registerChatTopics_InvalidTopic
  - 변경: “DB에 없음 → INVALID_TOPIC” 시나리오 제거
  - 새 시나리오: topicName=null 입력 시 INVALID_TOPIC 발생 검증
  - 부수 효과: chatTopicRepository는 호출되지 않아야 함을 검증

# 👀 Checkpoints for Reviewers


# 📚 References & Resources


# 🎯 Related Issues
- close#115


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 안내(Guide) 응답에서 직무명이 문자열로 제공되며 직무 설명 필드가 추가되었습니다. 가이드 상세, 목록, 생성/수정 응답 모두 동일 포맷을 사용합니다.

- 버그 수정
  - 채팅 주제 입력 검증이 강화되어 누락된 주제명(null) 입력을 즉시 거절합니다. 불필요한 내부 조회가 제외되어 검증 동작이 더 일관되고 예측 가능해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->