### PR TITLE
[fix] 멤버에서 가이드 업그레이드 로직, 프론트에서 연동 시 500 에러 발생

### DIFF
--- a/src/main/java/coffeandcommit/crema/global/auth/config/SecurityConfig.java
+++ b/src/main/java/coffeandcommit/crema/global/auth/config/SecurityConfig.java
@@ -92,21 +92,20 @@ public class SecurityConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
 
-        // 개발 환경과 프로덕션 환경의 모든 도메인 포함
+        // 명시적으로 각 도메인을 추가
         configuration.setAllowedOriginPatterns(List.of(
                 // 로컬 개발 환경
                 "http://localhost:3000",
                 "http://localhost:3001",
                 "http://localhost:8080",
-                // dev 서버 환경 (API 서버)
+                // dev 서버 환경
                 "https://dev-api-coffeechat.kro.kr",
-                // dev 서버 환경 (프론트엔드 서버 - 예상)
                 "https://dev-coffeechat.kro.kr",
                 "https://dev.coffeechat.kro.kr",
                 // 프로덕션 환경
                 "https://coffeechat.kro.kr",
                 "https://api.coffeechat.kro.kr",
-                // 모든 coffeechat.kro.kr 서브도메인 허용
+                // 와일드카드 패턴 (올바른 방법)
                 "https://*.coffeechat.kro.kr"
         ));
 
@@ -115,7 +114,7 @@ public class SecurityConfig {
         ));
 
         configuration.setAllowedHeaders(List.of("*"));
-        configuration.setAllowCredentials(true); // 쿠키 허용을 위해 필수
+        configuration.setAllowCredentials(true);
 
         // Preflight 요청 캐시 시간 설정 (1시간)
         configuration.setMaxAge(3600L);


### PR DESCRIPTION
# 🚀 What’s this PR about?
- 멤버에서 가이드 업그레이드 로직, 프론트에서 연동 시 500 에러 발생

# 🛠️ What’s been done?
- spring sercurity에서 multipart.form-data 요청을 허용하게 설정

# 🎯 Related Issues
closes #126 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 문서
  * 보안 설정의 CORS 관련 설명 주석을 명확히 다듬고 용어를 통일했습니다.
  * 도메인 예시 표현을 정제하고 중복·불필요한 설명을 제거했습니다.
  * 애플리케이션 동작, 접근 권한, 인증 절차, 허용 도메인·메서드·헤더 구성에는 변경이 없습니다.
  * 사용자 경험, 기능, 성능, 호환성에 영향이 없습니다.
  * 업데이트는 유지보수성 향상과 문서 가독성 개선에 초점을 맞췄으며, 배포 후 추가 조치는 필요 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->