### PR TITLE
가이드 영업 중 여부

### DIFF
--- a/src/main/java/coffeandcommit/crema/domain/guide/controller/GuideMeController.java
+++ b/src/main/java/coffeandcommit/crema/domain/guide/controller/GuideMeController.java
@@ -327,5 +327,25 @@ public class GuideMeController {
         return ResponseEntity.ok(response);
     }
 
+    @Operation(summary = "가이드 공개 상태 변경", description = "가이드의 공개 상태를 변경합니다.")
+    @PatchMapping("/visibility")
+    public ResponseEntity<Response<Void>> updateGuideVisibility(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody GuideVisibilityRequestDTO guideVisibilityRequestDTO) {
+
+        if (userDetails == null) {
+            throw new BaseException(ErrorStatus.UNAUTHORIZED);
+        }
+        String loginMemberId = userDetails.getMemberId();
+
+        guideMeService.updateGuideVisibility(loginMemberId, guideVisibilityRequestDTO);
+
+        Response<Void> response = Response.<Void>builder()
+                .message("가이드 공개 상태 변경 완료")
+                .data(null)
+                .build();
+
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
 
 }

--- a/src/main/java/coffeandcommit/crema/domain/guide/dto/request/GuideVisibilityRequestDTO.java
+++ b/src/main/java/coffeandcommit/crema/domain/guide/dto/request/GuideVisibilityRequestDTO.java
@@ -1,0 +1,17 @@
+package coffeandcommit.crema.domain.guide.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class GuideVisibilityRequestDTO {
+
+    @JsonProperty("isOpened")
+    private boolean isOpened;
+}

--- a/src/main/java/coffeandcommit/crema/domain/guide/entity/Guide.java
+++ b/src/main/java/coffeandcommit/crema/domain/guide/entity/Guide.java
@@ -87,4 +87,9 @@ public class Guide extends BaseEntity {
     @OneToOne(mappedBy = "guide", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     private ExperienceDetail experienceDetail;
 
+    public void updateVisibility(boolean isOpened) {
+        this.isOpened = isOpened;
+    }
+
+
 }

--- a/src/main/java/coffeandcommit/crema/domain/guide/service/GuideMeService.java
+++ b/src/main/java/coffeandcommit/crema/domain/guide/service/GuideMeService.java
@@ -578,4 +578,14 @@ public class GuideMeService {
         };
     }
 
+    /* 가이드 노출 설정 변경 */
+    @Transactional
+    public void updateGuideVisibility(String loginMemberId, GuideVisibilityRequestDTO guideVisibilityRequestDTO) {
+
+        Guide guide = guideRepository.findByMember_Id(loginMemberId)
+                .orElseThrow(() -> new BaseException(ErrorStatus.GUIDE_NOT_FOUND));
+
+        guide.updateVisibility(guideVisibilityRequestDTO.isOpened());
+
+    }
 }

--- a/src/main/java/coffeandcommit/crema/global/httpTest/GuideMeService.http
+++ b/src/main/java/coffeandcommit/crema/global/httpTest/GuideMeService.http
@@ -11,7 +11,7 @@ POST http://localhost:8080/api/test/auth/login
 Content-Type: application/json
 
 {
-  "nickname": "guide_fb969dd6"
+  "nickname": "guide_2b2a553d"
 }
 
 ### 7. 가이드 경험 등록 (enum 기반, 새로운 스펙)
@@ -78,4 +78,23 @@ Content-Type: application/json
     { "topicName": "직무 전환" },
     { "topicName": "COVER_LETTER" }
   ]
+}
+
+### 6. 가이드 공개 여부 변경 (토글 OFF)
+PATCH http://localhost:8080/api/guides/me/visibility
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiI2NDMwZGE4MCIsInR5cGUiOiJhY2Nlc3MiLCJqdGkiOiIyMGE3NmM5ZS01NGQ3LTQxOTAtOWU2NC1iOWUwNzc3YzcwNTQiLCJpYXQiOjE3NTc2MDIxNjQsImV4cCI6MTc1NzYwMzk2NH0.ff86ID61Gc560nVuFbqCpL-K7pMRPC2I7pjjxuBcaYaAvcAhDRn9MmTpwvpn4RS9_L3Iv7FE53Y2O2mHI-0TDA
+Content-Type: application/json
+
+{
+  "isOpened": false
+}
+
+### 7. 가이드 커피챗 주제 등록 (GuideCoffeeChatResponse)
+POST http://localhost:8080/api/guides/me/coffeechat
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiI2NDMwZGE4MCIsInR5cGUiOiJhY2Nlc3MiLCJqdGkiOiIyMGE3NmM5ZS01NGQ3LTQxOTAtOWU2NC1iOWUwNzc3YzcwNTQiLCJpYXQiOjE3NTc2MDIxNjQsImV4cCI6MTc1NzYwMzk2NH0.ff86ID61Gc560nVuFbqCpL-K7pMRPC2I7pjjxuBcaYaAvcAhDRn9MmTpwvpn4RS9_L3Iv7FE53Y2O2mHI-0TDA
+Content-Type: application/json
+
+{
+"title": "커피챗 제목 예시",
+"chatDescription": "이 커피챗은 직무 전환 및 커리어 관련 상담을 다룹니다."
 }


### PR DESCRIPTION
# 🚀 What’s this PR about?

-가이드 영업중 여부 기능 구현 및 테스트 코드 작성

# 🛠️ What’s been done?

- 제목과 설명을 입력하면 바로 영업중이 되는데 그 뒤 자신의 영업 여부를 조절하기 위한 입력값 구현

# 🧪 Testing Details

- updateGuideVisibility 성공 - 영업중(false→true) 전환 
- updateGuideVisibility 성공 - 영업중(true→false) 전환

# 👀 Checkpoints for Reviewers



# 📚 References & Resources


# 🎯 Related Issues
close#134


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 로그인한 가이드가 프로필 공개 여부를 토글할 수 있습니다. 공개/비공개 전환 시 성공 메시지와 함께 처리됩니다. 인증되지 않은 요청은 접근 불가 오류로 응답합니다.
- 테스트
  - 공개/비공개 전환 성공 및 가이드 미존재 오류 케이스에 대한 단위 테스트를 추가해 안정성을 강화했습니다.
- 기타
  - 수동 테스트 스크립트를 업데이트해 가이드 공개 여부 변경과 커피챗 주제 등록 시나리오를 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->