### PR TITLE
[Fix] videocall 참가자 검증 로직 변경

### DIFF
--- a/src/main/java/coffeandcommit/crema/domain/videocall/controller/VideoCallFileController.java
+++ b/src/main/java/coffeandcommit/crema/domain/videocall/controller/VideoCallFileController.java
@@ -41,10 +41,9 @@ public class VideoCallFileController {
             @PathVariable String sessionId,
             @AuthenticationPrincipal UserDetails userDetails) {
 
-        String userId = userDetails.getUsername();
-        log.info("공유 자료 목록 조회 요청 - 세션: {}, 사용자: {}", sessionId, userId);
+        log.info("공유 자료 목록 조회 요청 - 세션: {}, 사용자: {}", sessionId, userDetails.getUsername());
 
-        SharedFileListResponse response = videoCallFileService.getSharedFiles(sessionId, userId);
+        SharedFileListResponse response = videoCallFileService.getSharedFiles(sessionId, userDetails);
 
         return ApiResponse.onSuccess(SuccessStatus.OK, response);
     }
@@ -69,10 +68,9 @@ public class VideoCallFileController {
             @Valid @RequestBody SharedFileUploadRequest request,
             @AuthenticationPrincipal UserDetails userDetails) {
 
-        String userId = userDetails.getUsername();
-        log.info("공유 자료 등록 요청 - 세션: {}, 파일: {}, 사용자: {}", sessionId, request.getFileName(), userId);
+        log.info("공유 자료 등록 요청 - 세션: {}, 파일: {}, 사용자: {}", sessionId, request.getFileName(), userDetails.getUsername());
 
-        SharedFileResponse response = videoCallFileService.addSharedFile(sessionId, request, userId);
+        SharedFileResponse response = videoCallFileService.addSharedFile(sessionId, request, userDetails);
 
         return ApiResponse.onSuccess(SuccessStatus.CREATED, response);
     }
@@ -94,10 +92,9 @@ public class VideoCallFileController {
             @RequestParam("imageKey") String imageKey,
             @AuthenticationPrincipal UserDetails userDetails) {
 
-        String userId = userDetails.getUsername();
-        log.info("공유 자료 삭제 요청 - 세션: {}, 이미지키: {}, 사용자: {}", sessionId, imageKey, userId);
+        log.info("공유 자료 삭제 요청 - 세션: {}, 이미지키: {}, 사용자: {}", sessionId, imageKey, userDetails.getUsername());
 
-        videoCallFileService.deleteSharedFile(sessionId, imageKey, userId);
+        videoCallFileService.deleteSharedFile(sessionId, imageKey, userDetails);
 
         return ApiResponse.onSuccess(SuccessStatus.OK, null);
     }


### PR DESCRIPTION
# 🚀 What’s this PR about?

- 참가자 검증 로직을 변경합니다

# 🛠️ What’s been done?

- 기존 : username
- 변경 : member객체

# 🧪 Testing Details

- X

# 👀 Checkpoints for Reviewers

- X

# 📚 References & Resources

- X

# 🎯 Related Issues


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 버그 수정
  * 파일 공유 접근 제어 강화: 활성화된 화상 세션의 참여자만 조회/업로드/삭제 가능하도록 수정
  * 삭제 권한 제한: 공유 파일은 업로더 본인만 삭제 가능
  * 오류 처리 개선: 계정 미존재, 세션 비활성 등의 상황에 대한 응답과 메시지 일관성 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->