### PR TITLE
feat: 화상통화 테스트 API 및 예외 처리 추가

### DIFF
--- a/src/main/java/coffeandcommit/crema/domain/videocall/controller/VideoCallController.java
+++ b/src/main/java/coffeandcommit/crema/domain/videocall/controller/VideoCallController.java
@@ -40,6 +40,38 @@ public class VideoCallController {
         return ApiResponse.onSuccess(SuccessStatus.OK, response);
     }
 
+    @PostMapping("/test-quick-join")
+    @Operation(
+            summary = "세션 참가(자동 세션생성) - 테스트용/Auth 있음",
+            description = "인증 없이 세션에 참가할 수 있는 테스트용 API입니다."
+    )
+    public ApiResponse<QuickJoinResponse> quickJoin(
+            @RequestParam String sessionName,
+            @AuthenticationPrincipal UserDetails userDetails
+    ) {
+        long startTime = System.currentTimeMillis();
+        log.info("[QUICKJOIN-REQUEST] 테스트 quickjoin 요청 시작 - sessionName: {}",sessionName);
+
+        if (sessionName == null || sessionName.trim().isEmpty()) {
+            log.error("[QUICKJOIN-REQUEST] 잘못된 sessionName 파라미터: {}", sessionName);
+        }
+
+        try {
+            QuickJoinResponse response = videoCallService.testQuickJoinAuth(sessionName, userDetails);
+            long processingTime = System.currentTimeMillis() - startTime;
+
+            log.info("[QUICKJOIN-RESPONSE] 테스트 quickjoin 요청 성공 - sessionName: {}, " +
+                    "sessionId: {}, 처리시간: {}ms", sessionName, response.getSessionId(), processingTime);
+
+            return ApiResponse.onSuccess(SuccessStatus.OK, response);
+        } catch (Exception e) {
+            long processingTime = System.currentTimeMillis() - startTime;
+            log.error("[QUICKJOIN-ERROR] 테스트 quickjoin 요청 실패 - sessionName: {}, " +
+                    "처리시간: {}ms, error: {}", sessionName, processingTime, e.getMessage(), e);
+            throw e;
+        }
+    }
+
     @GetMapping("/config")
     @Operation(summary = "프론트엔드 연결 정보")
     public ApiResponse<SessionConfigResponse> getSessionConfig() {
@@ -88,11 +120,6 @@ public class VideoCallController {
     public ApiResponse<ParticipantInfoResponse> getParticipantInfo(
             @AuthenticationPrincipal UserDetails userDetails,
             @PathVariable String sessionId) {
-        // TODO: 구현 필요
-        // 1. sessionId로 VideoSession 조회
-        // 2. VideoSession의 reservation 정보에서 member, guide 정보 확인
-        // 3. 요청자(userDetails.getUsername())의 역할 확인
-        // 4. 상대방 정보를 ParticipantInfoResponse로 변환하여 반환
         ParticipantInfoResponse response = videoCallService.getParticipantInfo(sessionId, userDetails.getUsername());
         return ApiResponse.onSuccess(SuccessStatus.OK, response);
     }

--- a/src/main/java/coffeandcommit/crema/domain/videocall/exception/VideoSessionReservationNotFoundException.java
+++ b/src/main/java/coffeandcommit/crema/domain/videocall/exception/VideoSessionReservationNotFoundException.java
@@ -1,0 +1,14 @@
+package coffeandcommit.crema.domain.videocall.exception;
+
+import coffeandcommit.crema.global.common.exception.BaseException;
+import coffeandcommit.crema.global.common.exception.code.ErrorStatus;
+
+public class VideoSessionReservationNotFoundException extends BaseException {
+    public VideoSessionReservationNotFoundException() {
+        super(ErrorStatus.RESERVATION_NOT_FOUND);
+    }
+    
+    public VideoSessionReservationNotFoundException(String detailMessage) {
+        super(ErrorStatus.RESERVATION_NOT_FOUND, detailMessage);
+    }
+}


### PR DESCRIPTION
# 🚀 What’s this PR about?

- 화상통화 기능에 테스트용 API 엔드포인트와 예외 처리 클래스를 추가했습니다.

# 🛠️ What’s been done?

  - 테스트용 API 추가: POST /api/video-call/test-quick-join 엔드포인트 추가      
  (인증 필요)
    - 개발/디버깅 편의성을 위한 테스트용 세션 참가 기능
    - 요청 처리 시간 측정 및 상세 로깅 구현
  - 예외 처리 개선: VideoSessionReservationNotFoundException 예외 클래스 생성    
    - videocall 도메인 내 일관된 예외 처리 패턴 적용
  - 로깅 강화: 세션 참가 로직에 성능 모니터링 및 에러 핸들링 개선

# 🧪 Testing Details

- X

# 👀 Checkpoints for Reviewers

- X

# 📚 References & Resources

- X

# 🎯 Related Issues


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 인증 사용자용 빠른 참가 테스트 엔드포인트 추가(POST /api/video-call/test-quick-join). 세션 이름으로 즉시 세션을 검색/생성하고 접속 토큰 및 세션 정보(세션 ID/이름, 사용자명, OpenVidu URL 등)를 반환합니다.
- 버그 수정
  - 세션 종료 시 예약 처리 안정성 향상(중복 완료 방지 및 예외 처리 강화)으로 예기치 않은 종료 오류를 감소시켰습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->