### PR TITLE
hotfix: videoSession Id 생성방식 수정

### DIFF
--- a/src/main/java/coffeandcommit/crema/domain/videocall/service/VideoCallService.java
+++ b/src/main/java/coffeandcommit/crema/domain/videocall/service/VideoCallService.java
@@ -27,6 +27,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -102,7 +103,8 @@ public class VideoCallService {
                         .findBySessionNameAndIsActiveTrue(inputSessionName)
                         .orElseThrow(() -> new SessionNotFoundException("세션 이름: " + inputSessionName + "를 찾을 수 없습니다"));
             }catch (SessionNotFoundException e) {
-                String sessionName = "reservation_" + inputSessionName + LocalDateTime.now().toString();
+                String sessionName = "reservation_" + inputSessionName + "_"
+                        + LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMddHHmm")).toString();
                 session = basicVideoCallService.createVideoSession(sessionName);
             }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - 영상통화 세션 이름의 타임스탬프를 compact 숫자 형식(yyyyMMddHHmm)으로 표준화하여 가독성, 일관성, 목록 정렬 및 검색 편의성을 개선했습니다.
  - 세션 표기 형식 외의 동작 변화는 없으며, UI와 통화 흐름, 기존 초대 링크 및 접근 방식은 그대로 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->