### PR TITLE
hotfix: videoSession 멤버 조회방식 변경

### DIFF
--- a/src/main/java/coffeandcommit/crema/domain/videocall/service/BasicVideoCallService.java
+++ b/src/main/java/coffeandcommit/crema/domain/videocall/service/BasicVideoCallService.java
@@ -456,7 +456,7 @@ public class BasicVideoCallService {
             log.info("[SESSION-JOIN] DB에서 회원 정보 조회 시작: '{}'", userName);
             
             long memberStartTime = System.currentTimeMillis();
-            Optional<Member> byNicknameAndIsDeletedFalse = memberRepository.findByNicknameAndIsDeletedFalse(userName);
+            Optional<Member> byNicknameAndIsDeletedFalse = memberRepository.findByIdAndIsDeletedFalse(userName);
             long memberElapsedTime = System.currentTimeMillis() - memberStartTime;
             
             if(byNicknameAndIsDeletedFalse.isEmpty()){
@@ -590,7 +590,7 @@ public class BasicVideoCallService {
             Participant participant = Participant.builder()
                     .connectionId(connection.getConnectionId())
                     .token(token)
-                    .username(userName)
+                    .username(member.getNickname())
                     .videoSession(videoSession)
                     .member(member)
                     .build();

--- a/src/main/java/coffeandcommit/crema/domain/videocall/service/VideoCallService.java
+++ b/src/main/java/coffeandcommit/crema/domain/videocall/service/VideoCallService.java
@@ -76,11 +76,12 @@ public class VideoCallService {
             }
             
             String token = basicVideoCallService.joinSession(session.getSessionId(), userDetails.getUsername());
-            
+            Member member = memberRepository.findByIdAndIsDeletedFalse(userDetails.getUsername()).orElseThrow(ParticipantNotFound::new);
+
             return QuickJoinResponse.builder()
                     .sessionId(session.getSessionId())
                     .sessionName(session.getSessionName())
-                    .username(userDetails.getUsername())
+                    .username(member.getNickname())
                     .token(token)
                     .openviduServerUrl("https://" + openviduDomain)
                     .apiBaseUrl("https://" + openviduDomain)
@@ -90,7 +91,7 @@ public class VideoCallService {
                     .build();
             
         } catch (Exception e) {
-            throw new SessionConnectFailed();
+            throw e;
         }
     }
 
@@ -109,11 +110,13 @@ public class VideoCallService {
             }
 
             String token = basicVideoCallService.joinSession(session.getSessionId(), userDetails.getUsername());
+            Member member = memberRepository.findByIdAndIsDeletedFalse(userDetails.getUsername()).orElseThrow(ParticipantNotFound::new);
+
 
             return QuickJoinResponse.builder()
                     .sessionId(session.getSessionId())
                     .sessionName(session.getSessionName())
-                    .username(userDetails.getUsername())
+                    .username(member.getNickname())
                     .token(token)
                     .openviduServerUrl("https://" + openviduDomain)
                     .apiBaseUrl("https://" + openviduDomain)
@@ -123,7 +126,7 @@ public class VideoCallService {
                     .build();
 
         } catch (Exception e) {
-            throw new SessionConnectFailed();
+            throw e;
         }
     }
 
@@ -240,7 +243,7 @@ public class VideoCallService {
 
     public ParticipantInfoResponse getParticipantInfo(String sessionId, String username) {
 
-        Member member = memberRepository.findByNicknameAndIsDeletedFalse(username)
+        Member member = memberRepository.findByIdAndIsDeletedFalse(username)
                 .orElseThrow(ParticipantNotFound::new);
         VideoSession videoSession = videoSessionRepository.findBySessionId(sessionId)
                 .orElseThrow(SessionNotFoundException::new);
@@ -268,7 +271,7 @@ public class VideoCallService {
     public void endSession(String sessionId, ChatHistorySaveRequest chatHistory, String username) {
         try {
             // 1. Member 조회 및 역할 확인
-            Member member = memberRepository.findByNicknameAndIsDeletedFalse(username)
+            Member member = memberRepository.findByIdAndIsDeletedFalse(username)
                     .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다: " + username));
             
             log.info("세션 종료 요청: sessionId={}, username={}, role={}", sessionId, username, member.getRole());
@@ -329,7 +332,7 @@ public class VideoCallService {
                     log.warn("세션에 연결된 예약이 없습니다: sessionId={}", sessionId);
                 }
             }catch (Exception e) {
-                throw new VideoSessionReservationNotFoundException("in endsession");
+                throw e;
             }
             
             // DB 저장


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - 빠른 참가/인증 테스트에서 표시되는 사용자명이 계정의 닉네임으로 일관되게 노출되도록 수정.
  - 참가자 정보 조회 및 세션 종료 시 드물게 발생하던 연결 실패/세션 정보 불일치 오류 메시지 누락 문제 개선.

- Refactor
  - 사용자 식별 방식 정비로 회원 매칭 신뢰성과 화상회의 참가 흐름의 안정성 향상.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->