### PR TITLE
querydsl 도입으로 성능 개선

### DIFF
--- a/mock/front-dummy.json
+++ b/mock/front-dummy.json
@@ -1,0 +1,153 @@
+{
+  "members": [
+    {
+      "id": "MBR00001",
+      "nickname": "홍길동",
+      "role": "ROOKIE",
+      "point": 100,
+      "profileImageUrl": "https://cdn.example.com/profile1.png",
+      "description": "백엔드 지망생입니다.",
+      "provider": "GOOGLE",
+      "providerId": "google_123",
+      "isDeleted": false
+    },
+    {
+      "id": "MBR00002",
+      "nickname": "김선배",
+      "role": "GUIDE",
+      "point": 200,
+      "profileImageUrl": "https://cdn.example.com/profile2.png",
+      "description": "현직 백엔드 개발자입니다.",
+      "provider": "KAKAO",
+      "providerId": "kakao_456",
+      "isDeleted": false
+    }
+  ],
+  "guides": [
+    {
+      "id": 1,
+      "memberId": "MBR00002",
+      "chatDescription": "커피챗으로 면접 준비 도와드립니다.",
+      "isOpened": true,
+      "title": "백엔드 면접/이직 상담",
+      "certificationImageUrl": "https://cdn.example.com/cert1.png",
+      "approvedDate": "2025-09-01T12:00:00",
+      "workingStart": "2020-01-01",
+      "workingEnd": null,
+      "workingPeriod": null,
+      "companyName": "네이버",
+      "isCompanyNamePublic": true,
+      "jobPosition": "Backend Engineer",
+      "isCurrent": true
+    }
+  ],
+  "guideJobField": {"guideId": 1, "jobName": "IT_DEVELOPMENT_DATA"},
+  "guideChatTopics": [
+    {"id": 1, "guideId": 1, "chatTopicId": 1, "topicName": "INTERVIEW"},
+    {"id": 2, "guideId": 1, "chatTopicId": 3, "topicName": "JOB_CHANGE"}
+  ],
+  "hashTags": [
+    {"id": 1, "guideId": 1, "hashTagName": "#백엔드"},
+    {"id": 2, "guideId": 1, "hashTagName": "#면접준비"}
+  ],
+  "guideSchedules": [
+    {
+      "id": 1,
+      "guideId": 1,
+      "dayOfWeek": "MONDAY",
+      "timeSlots": [
+        {"id": 1, "startTimeOption": "09:00:00", "endTimeOption": "12:00:00"}
+      ]
+    },
+    {
+      "id": 2,
+      "guideId": 1,
+      "dayOfWeek": "WEDNESDAY",
+      "timeSlots": [
+        {"id": 2, "startTimeOption": "14:00:00", "endTimeOption": "18:00:00"}
+      ]
+    }
+  ],
+  "surveys": [
+    {"id": 1, "fileUploadUrl": "https://cdn.example.com/survey1-root.pdf", "messageToGuide": "면접 준비 조언 부탁드립니다.", "preferredDate": "2025-09-15T15:00:00"},
+    {"id": 2, "fileUploadUrl": "https://cdn.example.com/survey2-root.pdf", "messageToGuide": "자소서 피드백 받고 싶습니다.", "preferredDate": "2025-09-20T19:00:00"},
+    {"id": 3, "fileUploadUrl": "https://cdn.example.com/survey3-root.pdf", "messageToGuide": "프로젝트 코드 리뷰 받고 싶어요.", "preferredDate": "2025-09-22T20:00:00"},
+    {"id": 4, "fileUploadUrl": "https://cdn.example.com/survey4-root.pdf", "messageToGuide": "커리어 전환 조언 부탁드립니다.", "preferredDate": "2025-09-25T21:00:00"},
+    {"id": 5, "fileUploadUrl": "https://cdn.example.com/survey5-root.pdf", "messageToGuide": "포트폴리오 피드백 부탁드립니다.", "preferredDate": "2025-09-28T10:00:00"}
+  ],
+  "surveyFiles": [
+    {"id": 1, "surveyId": 1, "fileKey": "survey/1/file1.pdf"},
+    {"id": 2, "surveyId": 2, "fileKey": "survey/2/file1.pdf"},
+    {"id": 3, "surveyId": 3, "fileKey": "survey/3/file1.pdf"},
+    {"id": 4, "surveyId": 4, "fileKey": "survey/4/file1.pdf"},
+    {"id": 5, "surveyId": 5, "fileKey": "survey/5/file1.pdf"}
+  ],
+  "reservations": [
+    {"id": 1, "guideId": 1, "memberId": "MBR00001", "surveyId": 1, "matchingTime": "2025-09-15T15:00:00", "status": "COMPLETED"},
+    {"id": 2, "guideId": 1, "memberId": "MBR00001", "surveyId": 2, "matchingTime": "2025-09-20T19:00:00", "status": "PENDING"},
+    {"id": 3, "guideId": 1, "memberId": "MBR00001", "surveyId": 3, "matchingTime": "2025-09-22T20:00:00", "status": "COMPLETED"},
+    {"id": 4, "guideId": 1, "memberId": "MBR00001", "surveyId": 4, "matchingTime": "2025-09-25T21:00:00", "status": "COMPLETED"},
+    {"id": 5, "guideId": 1, "memberId": "MBR00001", "surveyId": 5, "matchingTime": "2025-09-28T10:00:00", "status": "COMPLETED"}
+  ],
+  "timeUnits": [
+    {"id": 1, "reservationId": 1, "timeType": "MINUTE_30"},
+    {"id": 2, "reservationId": 2, "timeType": "MINUTE_60"},
+    {"id": 3, "reservationId": 3, "timeType": "MINUTE_30"},
+    {"id": 4, "reservationId": 4, "timeType": "MINUTE_60"},
+    {"id": 5, "reservationId": 5, "timeType": "MINUTE_30"}
+  ],
+  "reviews": [
+    {"id": 1, "reservationId": 1, "comment": "면접 팁이 정말 유익했습니다!", "starReview": 4.5},
+    {"id": 2, "reservationId": 3, "comment": "프로젝트 코드 리뷰가 큰 도움이 됐어요.", "starReview": 5.0},
+    {"id": 3, "reservationId": 4, "comment": "커리어 전환 방향성을 잡을 수 있었어요.", "starReview": 4.0},
+    {"id": 4, "reservationId": 5, "comment": "포트폴리오 개선 포인트를 알게 되었어요.", "starReview": 3.5}
+  ],
+  "experienceGroups": [
+    {"id": 1, "guideId": 1, "guideChatTopicId": 1, "experienceTitle": "면접 경험", "experienceContent": "삼성전자 면접 합격 경험"},
+    {"id": 2, "guideId": 1, "guideChatTopicId": 2, "experienceTitle": "이직 경험", "experienceContent": "스타트업 → 대기업 전환기 이야기"}
+  ],
+  "experienceDetail": {"id": 1, "guideId": 1, "who": "신입 지원자", "solution": "코딩테스트 대비", "how": "스터디 그룹 운영"},
+  "reviewExperiences": [
+    {"id": 1, "reviewId": 1, "experienceGroupId": 1, "isThumbsUp": true},
+    {"id": 2, "reviewId": 2, "experienceGroupId": 1, "isThumbsUp": true},
+    {"id": 3, "reviewId": 3, "experienceGroupId": 2, "isThumbsUp": true},
+    {"id": 4, "reviewId": 4, "experienceGroupId": 2, "isThumbsUp": false}
+  ],
+  "meetingRooms": [
+    {"id": 1, "reservationId": 1, "startTime": "2025-09-15T15:00:00", "endTime": "2025-09-15T15:30:00", "roomUrl": "https://meet.example.com/room1"}
+  ],
+  "candidates": [
+    {"id": 1, "reservationId": 1, "timeId": 1, "priority": 1, "candidateDate": "2025-09-14T10:00:00"},
+    {"id": 2, "reservationId": 2, "timeId": 2, "priority": 2, "candidateDate": "2025-09-19T15:00:00"}
+  ],
+  "notifications": [
+    {"id": 1, "memberId": "MBR00001", "reservationId": 1, "message": "예약이 확정되었습니다.", "isRead": false},
+    {"id": 2, "memberId": "MBR00002", "reservationId": 1, "message": "새로운 후기가 등록되었습니다.", "isRead": false}
+  ],
+  "guideListResponse": {
+    "page": 0,
+    "size": 20,
+    "totalElements": 1,
+    "content": [
+      {
+        "guideId": 1,
+        "nickname": "김선배",
+        "profileImageUrl": "https://cdn.example.com/profile2.png",
+        "title": "백엔드 면접/이직 상담",
+        "workingPeriod": null,
+        "jobField": {"guideId": 1, "jobName": "IT_DEVELOPMENT_DATA"},
+        "hashTags": [
+          {"id": 1, "guideId": 1, "hashTagName": "#백엔드"},
+          {"id": 2, "guideId": 1, "hashTagName": "#면접준비"}
+        ],
+        "stats": {
+          "totalCoffeeChats": 4,
+          "averageStar": 4.3,
+          "totalReviews": 4,
+          "thumbsUpCount": 3
+        }
+      }
+    ]
+  }
+}
+

--- a/src/main/java/coffeandcommit/crema/domain/guide/controller/GuideController.java
+++ b/src/main/java/coffeandcommit/crema/domain/guide/controller/GuideController.java
@@ -277,6 +277,7 @@ public class GuideController {
         return ResponseEntity.ok(response);
     }
 
+    @Operation(summary = "가이드 목록 조회", description = "가이드 목록을 조회합니다. 필터링, 검색, 정렬, 페이지네이션 기능을 제공합니다.")
     @GetMapping
     public ResponseEntity<Response<Page<GuideListResponseDTO>>> getGuides(
             @RequestParam(required = false) List<JobNameType> jobNames,

--- a/src/main/java/coffeandcommit/crema/domain/guide/repository/GuideRepository.java
+++ b/src/main/java/coffeandcommit/crema/domain/guide/repository/GuideRepository.java
@@ -1,67 +1,16 @@
 package coffeandcommit.crema.domain.guide.repository;
 
 import coffeandcommit.crema.domain.guide.entity.Guide;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
-import coffeandcommit.crema.domain.globalTag.enums.JobNameType;
-import coffeandcommit.crema.domain.globalTag.enums.TopicNameType;
 
-import java.util.List;
 import java.util.Optional;
 
 @Repository
-public interface GuideRepository extends JpaRepository<Guide, Long> {
+public interface GuideRepository extends JpaRepository<Guide, Long>, GuideRepositoryCustom {
 
 
     Optional<Guide> findByMember_Id(String memberId);
 
-    /**
-     * 가이드 목록을 조회합니다.
-     * 조건에 따라 필터링된 가이드를 페이지 단위로 반환합니다.
-     * 영업 중(isOpened = true)인 가이드만 조회됩니다.
-     *
-     * @param jobNames 직무분야 이름 목록 (ENUM)
-     * @param chatTopicNames 커피챗 주제 이름 목록 (ENUM)
-     * @param keyword 검색 키워드 (title, hashTagName)
-     * @param pageable 페이징 정보
-     * @return 필터링된 가이드 목록
-     */
-    @Query(
-        value = """
-            SELECT DISTINCT g
-            FROM Guide g
-            LEFT JOIN g.guideJobField gjf
-            LEFT JOIN g.guideChatTopics gct
-            LEFT JOIN g.hashTags ht
-            WHERE g.isOpened = true
-              AND (:jobNames IS NULL OR gjf.jobName IN :jobNames)
-              AND (:chatTopicNames IS NULL OR gct.chatTopic.topicName IN :chatTopicNames)
-              AND (:keyword IS NULL
-                   OR LOWER(g.title) LIKE LOWER(CONCAT('%', :keyword, '%'))
-                   OR LOWER(ht.hashTagName) LIKE LOWER(CONCAT('%', :keyword, '%')))
-            """,
-        countQuery = """
-            SELECT COUNT(DISTINCT g)
-            FROM Guide g
-            LEFT JOIN g.guideJobField gjf
-            LEFT JOIN g.guideChatTopics gct
-            LEFT JOIN g.hashTags ht
-            WHERE g.isOpened = true
-              AND (:jobNames IS NULL OR gjf.jobName IN :jobNames)
-              AND (:chatTopicNames IS NULL OR gct.chatTopic.topicName IN :chatTopicNames)
-              AND (:keyword IS NULL
-                   OR LOWER(g.title) LIKE LOWER(CONCAT('%', :keyword, '%'))
-                   OR LOWER(ht.hashTagName) LIKE LOWER(CONCAT('%', :keyword, '%')))
-            """
-    )
-    Page<Guide> findBySearchConditions(
-            @Param("jobNames") List<JobNameType> jobNames,
-            @Param("chatTopicNames") List<TopicNameType> chatTopicNames,
-            @Param("keyword") String keyword,
-            Pageable pageable
-    );
+    // QueryDSL 구현은 GuideRepositoryImpl에서 처리
 }

--- a/src/main/java/coffeandcommit/crema/domain/guide/repository/GuideRepositoryCustom.java
+++ b/src/main/java/coffeandcommit/crema/domain/guide/repository/GuideRepositoryCustom.java
@@ -1,5 +1,7 @@
 package coffeandcommit.crema.domain.guide.repository;
 
+import coffeandcommit.crema.domain.globalTag.enums.JobNameType;
+import coffeandcommit.crema.domain.globalTag.enums.TopicNameType;
 import coffeandcommit.crema.domain.guide.entity.Guide;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -9,29 +11,10 @@ import java.util.List;
 public interface GuideRepositoryCustom {
 
     Page<Guide> findBySearchConditions(
-            List<Long> jobFieldIds,
-            List<Long> chatTopicIds,
+            List<JobNameType> jobNames,
+            List<TopicNameType> chatTopicNames,
             String keyword,
             Pageable pageable
-    );
-
-    Page<Guide> findBySearchConditionsOrderByReviewCount(
-            List<Long> jobFieldIds,
-            List<Long> chatTopicIds,
-            String keyword,
-            Pageable pageable
-    );
-
-    /**
-     * 필터 조건과 함께 집계 지표(리뷰수, 평균별점, 완료된 커피챗 수, 좋아요 수)를
-     * 단일 쿼리에서 계산하여 반환합니다.
-     * orderByReviewCount=true 면 인기순(리뷰수 DESC), 아니면 최신순(기본 pageable sort 적용)으로 정렬합니다.
-     */
-    Page<GuideWithStats> findBySearchConditionsWithStats(
-            List<Long> jobFieldIds,
-            List<Long> chatTopicIds,
-            String keyword,
-            Pageable pageable,
-            boolean orderByReviewCount
     );
 }
+

--- a/src/main/java/coffeandcommit/crema/domain/guide/repository/GuideRepositoryCustom.java
+++ b/src/main/java/coffeandcommit/crema/domain/guide/repository/GuideRepositoryCustom.java
@@ -1,0 +1,37 @@
+package coffeandcommit.crema.domain.guide.repository;
+
+import coffeandcommit.crema.domain.guide.entity.Guide;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+public interface GuideRepositoryCustom {
+
+    Page<Guide> findBySearchConditions(
+            List<Long> jobFieldIds,
+            List<Long> chatTopicIds,
+            String keyword,
+            Pageable pageable
+    );
+
+    Page<Guide> findBySearchConditionsOrderByReviewCount(
+            List<Long> jobFieldIds,
+            List<Long> chatTopicIds,
+            String keyword,
+            Pageable pageable
+    );
+
+    /**
+     * 필터 조건과 함께 집계 지표(리뷰수, 평균별점, 완료된 커피챗 수, 좋아요 수)를
+     * 단일 쿼리에서 계산하여 반환합니다.
+     * orderByReviewCount=true 면 인기순(리뷰수 DESC), 아니면 최신순(기본 pageable sort 적용)으로 정렬합니다.
+     */
+    Page<GuideWithStats> findBySearchConditionsWithStats(
+            List<Long> jobFieldIds,
+            List<Long> chatTopicIds,
+            String keyword,
+            Pageable pageable,
+            boolean orderByReviewCount
+    );
+}

--- a/src/main/java/coffeandcommit/crema/domain/guide/repository/GuideRepositoryImpl.java
+++ b/src/main/java/coffeandcommit/crema/domain/guide/repository/GuideRepositoryImpl.java
@@ -4,21 +4,16 @@ import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.ComparableExpressionBase;
-import com.querydsl.core.types.dsl.PathBuilder;
-import com.querydsl.core.types.dsl.NumberExpression;
-import com.querydsl.core.types.dsl.NumberPath;
-import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import coffeandcommit.crema.domain.globalTag.enums.JobNameType;
+import coffeandcommit.crema.domain.globalTag.enums.TopicNameType;
 import coffeandcommit.crema.domain.guide.entity.Guide;
 import coffeandcommit.crema.domain.guide.entity.QGuide;
-import coffeandcommit.crema.domain.guide.entity.QGuideChatTopic;
 import coffeandcommit.crema.domain.guide.entity.QGuideJobField;
 import coffeandcommit.crema.domain.guide.entity.QHashTag;
-import coffeandcommit.crema.domain.reservation.entity.QReservation;
-import coffeandcommit.crema.domain.review.entity.QReview;
-import coffeandcommit.crema.domain.review.entity.QReviewExperience;
-import coffeandcommit.crema.domain.guide.entity.QExperienceGroup;
-import coffeandcommit.crema.domain.reservation.enums.Status;
+import coffeandcommit.crema.domain.guide.entity.QGuideChatTopic;
+import coffeandcommit.crema.domain.globalTag.entity.QChatTopic;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
@@ -27,7 +22,6 @@ import org.springframework.stereotype.Repository;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 
 @Repository
 public class GuideRepositoryImpl implements GuideRepositoryCustom {
@@ -39,275 +33,74 @@ public class GuideRepositoryImpl implements GuideRepositoryCustom {
     }
 
     @Override
-    public Page<Guide> findBySearchConditions(List<Long> jobFieldIds, List<Long> chatTopicIds, String keyword, Pageable pageable) {
+    public Page<Guide> findBySearchConditions(List<JobNameType> jobNames, List<TopicNameType> chatTopicNames, String keyword, Pageable pageable) {
         QGuide g = QGuide.guide;
         QGuideJobField gjf = QGuideJobField.guideJobField;
-        QGuideChatTopic gct = QGuideChatTopic.guideChatTopic;
         QHashTag ht = QHashTag.hashTag;
+        QGuideChatTopic gct = QGuideChatTopic.guideChatTopic;
+        QChatTopic ct = QChatTopic.chatTopic;
 
         BooleanBuilder where = new BooleanBuilder();
         where.and(g.isOpened.isTrue());
 
-        if (jobFieldIds != null && !jobFieldIds.isEmpty()) {
-            // Guide has one GuideJobField
-            where.and(g.guideJobField.id.in(jobFieldIds));
+        // 직무 필터: 조인 후 enum 비교
+        if (jobNames != null && !jobNames.isEmpty()) {
+            where.and(g.guideJobField.jobName.in(jobNames));
         }
 
-        if (chatTopicIds != null && !chatTopicIds.isEmpty()) {
-            where.and(gct.chatTopic.id.in(chatTopicIds));
-        }
-
-        if (keyword != null && !keyword.isBlank()) {
-            String like = "%" + keyword.toLowerCase() + "%";
+        // 주제 필터: EXISTS로 행 증식 방지
+        if (chatTopicNames != null && !chatTopicNames.isEmpty()) {
             where.and(
-                    g.title.lower().like(like)
-                            .or(ht.hashTagName.lower().like(like))
+                    JPAExpressions.selectOne()
+                            .from(gct)
+                            .join(gct.chatTopic, ct)
+                            .where(gct.guide.eq(g)
+                                    .and(ct.topicName.in(chatTopicNames)))
+                            .exists()
             );
         }
 
-        // Base content query
+        // 키워드: 접두어 + EXISTS (태그)
+        if (keyword != null && !keyword.isBlank()) {
+            String likePrefix = keyword.trim().toLowerCase() + "%";
+            where.and(
+                    g.title.lower().like(likePrefix)
+                            .or(
+                                    JPAExpressions.selectOne()
+                                            .from(ht)
+                                            .where(ht.guide.eq(g)
+                                                    .and(ht.hashTagName.lower().like(likePrefix)))
+                                            .exists()
+                            )
+            );
+        }
+
         var contentQuery = queryFactory
-                .selectDistinct(g)
-                .from(g)
-                .leftJoin(g.guideJobField, gjf)
-                .leftJoin(g.guideChatTopics, gct)
-                .leftJoin(g.hashTags, ht)
-                .where(where);
-
-        // Apply sorting from pageable
-        for (OrderSpecifier<?> orderSpecifier : toOrderSpecifiers(pageable.getSort(), g)) {
-            contentQuery.orderBy(orderSpecifier);
-        }
-
-        List<Guide> content;
-        long total;
-
-        if (pageable.isUnpaged()) {
-            content = contentQuery.fetch();
-            // Count matches distinct guides
-            total = queryFactory
-                    .select(g.id.countDistinct())
-                    .from(g)
-                    .leftJoin(g.guideJobField, gjf)
-                    .leftJoin(g.guideChatTopics, gct)
-                    .leftJoin(g.hashTags, ht)
-                    .where(where)
-                    .fetchFirst();
-        } else {
-            content = contentQuery
-                    .offset(pageable.getOffset())
-                    .limit(pageable.getPageSize())
-                    .fetch();
-
-            total = Objects.requireNonNullElse(
-                    queryFactory
-                            .select(g.id.countDistinct())
-                            .from(g)
-                            .leftJoin(g.guideJobField, gjf)
-                            .leftJoin(g.guideChatTopics, gct)
-                            .leftJoin(g.hashTags, ht)
-                            .where(where)
-                            .fetchFirst(),
-                    0L
-            );
-        }
-
-        return new PageImpl<>(content, pageable, total);
-    }
-
-    @Override
-    public Page<Guide> findBySearchConditionsOrderByReviewCount(List<Long> jobFieldIds, List<Long> chatTopicIds, String keyword, Pageable pageable) {
-        QGuide g = QGuide.guide;
-        QGuideJobField gjf = QGuideJobField.guideJobField;
-        QGuideChatTopic gct = QGuideChatTopic.guideChatTopic;
-        QHashTag ht = QHashTag.hashTag;
-        QReservation res = QReservation.reservation;
-        QReview rev = QReview.review;
-
-        BooleanBuilder where = new BooleanBuilder();
-        where.and(g.isOpened.isTrue());
-
-        if (jobFieldIds != null && !jobFieldIds.isEmpty()) {
-            where.and(g.guideJobField.id.in(jobFieldIds));
-        }
-
-        if (chatTopicIds != null && !chatTopicIds.isEmpty()) {
-            where.and(gct.chatTopic.id.in(chatTopicIds));
-        }
-
-        if (keyword != null && !keyword.isBlank()) {
-            String like = "%" + keyword.toLowerCase() + "%";
-            where.and(
-                    g.title.lower().like(like)
-                            .or(ht.hashTagName.lower().like(like))
-            );
-        }
-
-        NumberExpression<Long> reviewCount = rev.id.countDistinct();
-
-        var baseQuery = queryFactory
                 .select(g)
                 .from(g)
                 .leftJoin(g.guideJobField, gjf)
-                .leftJoin(g.guideChatTopics, gct)
-                .leftJoin(g.hashTags, ht)
-                .leftJoin(res).on(res.guide.eq(g))
-                .leftJoin(rev).on(rev.reservation.eq(res))
-                .where(where)
-                .groupBy(g.id)
-                .orderBy(reviewCount.desc(), g.modifiedAt.desc());
+                .where(where);
 
-        List<Guide> content;
-        long total;
-
-        if (pageable.isUnpaged()) {
-            content = baseQuery.fetch();
-        } else {
-            content = baseQuery
-                    .offset(pageable.getOffset())
-                    .limit(pageable.getPageSize())
-                    .fetch();
+        // 정렬 적용 (허용 필드만)
+        for (OrderSpecifier<?> os : toOrderSpecifiers(pageable.getSort(), g)) {
+            contentQuery.orderBy(os);
         }
 
-        total = Objects.requireNonNullElse(
-                queryFactory
-                        .select(g.id.countDistinct())
-                        .from(g)
-                        .leftJoin(g.guideJobField, gjf)
-                        .leftJoin(g.guideChatTopics, gct)
-                        .leftJoin(g.hashTags, ht)
-                        .where(where)
-                        .fetchFirst(),
-                0L
-        );
-
-        return new PageImpl<>(content, pageable, total);
-    }
-
-    @Override
-    public Page<GuideWithStats> findBySearchConditionsWithStats(List<Long> jobFieldIds, List<Long> chatTopicIds, String keyword, Pageable pageable, boolean orderByReviewCount) {
-        QGuide g = QGuide.guide;
-        QGuideJobField gjf = QGuideJobField.guideJobField;
-        QGuideChatTopic gct = QGuideChatTopic.guideChatTopic;
-        QHashTag ht = QHashTag.hashTag;
-        QReservation res = QReservation.reservation;
-        QReview rev = QReview.review;
-        QReviewExperience rex = QReviewExperience.reviewExperience;
-        QExperienceGroup eg = QExperienceGroup.experienceGroup;
-
-        BooleanBuilder where = new BooleanBuilder();
-        where.and(g.isOpened.isTrue());
-
-        if (jobFieldIds != null && !jobFieldIds.isEmpty()) {
-            where.and(g.guideJobField.id.in(jobFieldIds));
-        }
-
-        if (chatTopicIds != null && !chatTopicIds.isEmpty()) {
-            where.and(gct.chatTopic.id.in(chatTopicIds));
-        }
-
-        if (keyword != null && !keyword.isBlank()) {
-            String like = "%" + keyword.toLowerCase() + "%";
-            where.and(
-                    g.title.lower().like(like)
-                            .or(ht.hashTagName.lower().like(like))
-            );
-        }
-
-        // 리뷰 수 (서브쿼리): 가이드에 귀속된 리뷰 개수
-        var reviewCount = com.querydsl.jpa.JPAExpressions
-                .select(rev.id.count())
-                .from(rev)
-                .join(rev.reservation, res)
-                .where(res.guide.eq(g));
-
-        // 평균 별점 (서브쿼리): 가이드 리뷰의 평균 별점
-        var avgStar = com.querydsl.jpa.JPAExpressions
-                .select(rev.starReview.avg())
-                .from(rev)
-                .join(rev.reservation, res)
-                .where(res.guide.eq(g));
-
-        // 완료된 커피챗 수 (서브쿼리): COMPLETED 상태 예약 수
-        var completedChats = com.querydsl.jpa.JPAExpressions
-                .select(res.id.countDistinct())
-                .from(res)
-                .where(res.guide.eq(g).and(res.status.eq(Status.COMPLETED)));
-
-        // 좋아요 수 (서브쿼리): 해당 가이드의 경험 그룹에 달린 thumbs up 개수
-        var thumbsUpCount = com.querydsl.jpa.JPAExpressions
-                .select(rex.id.count())
-                .from(rex)
-                .join(rex.experienceGroup, eg)
-                .where(eg.guide.eq(g).and(rex.isThumbsUp.isTrue()));
-
-        // content query: 필터를 위한 조인만 하고, 집계는 서브쿼리로 안전하게 계산
-        var contentQuery = queryFactory
-                .select(g, reviewCount, avgStar, completedChats, thumbsUpCount)
-                .from(g)
-                .leftJoin(g.guideJobField, gjf)
-                .leftJoin(g.guideChatTopics, gct)
-                .leftJoin(g.hashTags, ht)
-                .where(where)
-                .groupBy(g.id);
-
-        // 정렬: 인기순이면 리뷰 수 DESC 우선, 아니면 pageable 정렬(기본 modifiedAt DESC)
-        if (orderByReviewCount) {
-            // 서브쿼리는 desc()가 없으므로 명시적으로 OrderSpecifier 사용
-            contentQuery.orderBy(new OrderSpecifier<>(Order.DESC, reviewCount), g.modifiedAt.desc());
-        } else {
-            for (OrderSpecifier<?> orderSpecifier : toOrderSpecifiers(pageable.getSort(), g)) {
-                contentQuery.orderBy(orderSpecifier);
-            }
-        }
-
-        var tuples = pageable.isUnpaged()
+        List<Guide> content = pageable.isUnpaged()
                 ? contentQuery.fetch()
                 : contentQuery.offset(pageable.getOffset()).limit(pageable.getPageSize()).fetch();
 
-        List<GuideWithStats> content = new java.util.ArrayList<>(tuples.size());
-        tuples.forEach(t -> {
-            Guide guide = t.get(0, Guide.class);
-            // Hibernate/Dialect에 따라 COUNT/AVG 타입이 BigInteger/Long/BigDecimal/Double 등으로 돌아올 수 있어 Number로 안전 처리
-            Number rcNum = t.get(1, Number.class); // reviewCount
-            Number asNum = t.get(2, Number.class); // avgStar
-            Number ccNum = t.get(3, Number.class); // completedChats
-            Number tuNum = t.get(4, Number.class); // thumbsUpCount
+        Long total = queryFactory
+                .select(g.id.countDistinct())
+                .from(g)
+                .leftJoin(g.guideJobField, gjf)
+                .where(where)
+                .fetchFirst();
 
-            long rc = rcNum == null ? 0L : rcNum.longValue();
-            long cc = ccNum == null ? 0L : ccNum.longValue();
-            long tu = tuNum == null ? 0L : tuNum.longValue();
-            double avg = asNum == null ? 0.0 : asNum.doubleValue();
-
-            content.add(GuideWithStats.builder()
-                    .guide(guide)
-                    .totalReviews(rc)
-                    .averageStar(avg)
-                    .totalCoffeeChats(cc)
-                    .thumbsUpCount(tu)
-                    .build());
-        });
-
-        long total = Objects.requireNonNullElse(
-                queryFactory
-                        .select(g.id.countDistinct())
-                        .from(g)
-                        .leftJoin(g.guideJobField, gjf)
-                        .leftJoin(g.guideChatTopics, gct)
-                        .leftJoin(g.hashTags, ht)
-                        .where(where)
-                        .fetchFirst(),
-                0L
-        );
-
-        return new PageImpl<>(content, pageable, total);
+        return new PageImpl<>(content, pageable, total == null ? 0L : total);
     }
 
-    /**
-     * 안전한 정렬 매핑: 허용된 속성만 Q타입으로 매핑한다.
-     * - PathBuilder.get(property) 사용 시 존재하지 않는 프로퍼티/타입 불일치로 런타임 오류가 날 수 있어
-     *   명시적으로 필요한 필드만 처리한다.
-     */
+    // 허용된 정렬 키만 매핑
     private List<OrderSpecifier<?>> toOrderSpecifiers(Sort sort, QGuide g) {
         List<OrderSpecifier<?>> orders = new ArrayList<>();
         if (sort == null) return orders;
@@ -317,16 +110,13 @@ public class GuideRepositoryImpl implements GuideRepositoryCustom {
                 case "modifiedAt" -> g.modifiedAt;
                 case "createdAt" -> g.createdAt;
                 case "title" -> g.title;
-                case "approvedDate" -> g.approvedDate;
-                case "companyName" -> g.companyName;
-                default -> null; // 알 수 없는 정렬 키는 무시
+                default -> null;
             };
-
             if (expr != null) {
-                Order direction = o.isAscending() ? Order.ASC : Order.DESC;
-                orders.add(new OrderSpecifier<>(direction, expr));
+                orders.add(new OrderSpecifier<>(o.isAscending() ? Order.ASC : Order.DESC, expr));
             }
         }
         return orders;
     }
 }
+

--- a/src/main/java/coffeandcommit/crema/domain/guide/repository/GuideRepositoryImpl.java
+++ b/src/main/java/coffeandcommit/crema/domain/guide/repository/GuideRepositoryImpl.java
@@ -1,0 +1,332 @@
+package coffeandcommit.crema.domain.guide.repository;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.ComparableExpressionBase;
+import com.querydsl.core.types.dsl.PathBuilder;
+import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.core.types.dsl.NumberPath;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import coffeandcommit.crema.domain.guide.entity.Guide;
+import coffeandcommit.crema.domain.guide.entity.QGuide;
+import coffeandcommit.crema.domain.guide.entity.QGuideChatTopic;
+import coffeandcommit.crema.domain.guide.entity.QGuideJobField;
+import coffeandcommit.crema.domain.guide.entity.QHashTag;
+import coffeandcommit.crema.domain.reservation.entity.QReservation;
+import coffeandcommit.crema.domain.review.entity.QReview;
+import coffeandcommit.crema.domain.review.entity.QReviewExperience;
+import coffeandcommit.crema.domain.guide.entity.QExperienceGroup;
+import coffeandcommit.crema.domain.reservation.enums.Status;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Repository;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+@Repository
+public class GuideRepositoryImpl implements GuideRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    public GuideRepositoryImpl(JPAQueryFactory queryFactory) {
+        this.queryFactory = queryFactory;
+    }
+
+    @Override
+    public Page<Guide> findBySearchConditions(List<Long> jobFieldIds, List<Long> chatTopicIds, String keyword, Pageable pageable) {
+        QGuide g = QGuide.guide;
+        QGuideJobField gjf = QGuideJobField.guideJobField;
+        QGuideChatTopic gct = QGuideChatTopic.guideChatTopic;
+        QHashTag ht = QHashTag.hashTag;
+
+        BooleanBuilder where = new BooleanBuilder();
+        where.and(g.isOpened.isTrue());
+
+        if (jobFieldIds != null && !jobFieldIds.isEmpty()) {
+            // Guide has one GuideJobField
+            where.and(g.guideJobField.id.in(jobFieldIds));
+        }
+
+        if (chatTopicIds != null && !chatTopicIds.isEmpty()) {
+            where.and(gct.chatTopic.id.in(chatTopicIds));
+        }
+
+        if (keyword != null && !keyword.isBlank()) {
+            String like = "%" + keyword.toLowerCase() + "%";
+            where.and(
+                    g.title.lower().like(like)
+                            .or(ht.hashTagName.lower().like(like))
+            );
+        }
+
+        // Base content query
+        var contentQuery = queryFactory
+                .selectDistinct(g)
+                .from(g)
+                .leftJoin(g.guideJobField, gjf)
+                .leftJoin(g.guideChatTopics, gct)
+                .leftJoin(g.hashTags, ht)
+                .where(where);
+
+        // Apply sorting from pageable
+        for (OrderSpecifier<?> orderSpecifier : toOrderSpecifiers(pageable.getSort(), g)) {
+            contentQuery.orderBy(orderSpecifier);
+        }
+
+        List<Guide> content;
+        long total;
+
+        if (pageable.isUnpaged()) {
+            content = contentQuery.fetch();
+            // Count matches distinct guides
+            total = queryFactory
+                    .select(g.id.countDistinct())
+                    .from(g)
+                    .leftJoin(g.guideJobField, gjf)
+                    .leftJoin(g.guideChatTopics, gct)
+                    .leftJoin(g.hashTags, ht)
+                    .where(where)
+                    .fetchFirst();
+        } else {
+            content = contentQuery
+                    .offset(pageable.getOffset())
+                    .limit(pageable.getPageSize())
+                    .fetch();
+
+            total = Objects.requireNonNullElse(
+                    queryFactory
+                            .select(g.id.countDistinct())
+                            .from(g)
+                            .leftJoin(g.guideJobField, gjf)
+                            .leftJoin(g.guideChatTopics, gct)
+                            .leftJoin(g.hashTags, ht)
+                            .where(where)
+                            .fetchFirst(),
+                    0L
+            );
+        }
+
+        return new PageImpl<>(content, pageable, total);
+    }
+
+    @Override
+    public Page<Guide> findBySearchConditionsOrderByReviewCount(List<Long> jobFieldIds, List<Long> chatTopicIds, String keyword, Pageable pageable) {
+        QGuide g = QGuide.guide;
+        QGuideJobField gjf = QGuideJobField.guideJobField;
+        QGuideChatTopic gct = QGuideChatTopic.guideChatTopic;
+        QHashTag ht = QHashTag.hashTag;
+        QReservation res = QReservation.reservation;
+        QReview rev = QReview.review;
+
+        BooleanBuilder where = new BooleanBuilder();
+        where.and(g.isOpened.isTrue());
+
+        if (jobFieldIds != null && !jobFieldIds.isEmpty()) {
+            where.and(g.guideJobField.id.in(jobFieldIds));
+        }
+
+        if (chatTopicIds != null && !chatTopicIds.isEmpty()) {
+            where.and(gct.chatTopic.id.in(chatTopicIds));
+        }
+
+        if (keyword != null && !keyword.isBlank()) {
+            String like = "%" + keyword.toLowerCase() + "%";
+            where.and(
+                    g.title.lower().like(like)
+                            .or(ht.hashTagName.lower().like(like))
+            );
+        }
+
+        NumberExpression<Long> reviewCount = rev.id.countDistinct();
+
+        var baseQuery = queryFactory
+                .select(g)
+                .from(g)
+                .leftJoin(g.guideJobField, gjf)
+                .leftJoin(g.guideChatTopics, gct)
+                .leftJoin(g.hashTags, ht)
+                .leftJoin(res).on(res.guide.eq(g))
+                .leftJoin(rev).on(rev.reservation.eq(res))
+                .where(where)
+                .groupBy(g.id)
+                .orderBy(reviewCount.desc(), g.modifiedAt.desc());
+
+        List<Guide> content;
+        long total;
+
+        if (pageable.isUnpaged()) {
+            content = baseQuery.fetch();
+        } else {
+            content = baseQuery
+                    .offset(pageable.getOffset())
+                    .limit(pageable.getPageSize())
+                    .fetch();
+        }
+
+        total = Objects.requireNonNullElse(
+                queryFactory
+                        .select(g.id.countDistinct())
+                        .from(g)
+                        .leftJoin(g.guideJobField, gjf)
+                        .leftJoin(g.guideChatTopics, gct)
+                        .leftJoin(g.hashTags, ht)
+                        .where(where)
+                        .fetchFirst(),
+                0L
+        );
+
+        return new PageImpl<>(content, pageable, total);
+    }
+
+    @Override
+    public Page<GuideWithStats> findBySearchConditionsWithStats(List<Long> jobFieldIds, List<Long> chatTopicIds, String keyword, Pageable pageable, boolean orderByReviewCount) {
+        QGuide g = QGuide.guide;
+        QGuideJobField gjf = QGuideJobField.guideJobField;
+        QGuideChatTopic gct = QGuideChatTopic.guideChatTopic;
+        QHashTag ht = QHashTag.hashTag;
+        QReservation res = QReservation.reservation;
+        QReview rev = QReview.review;
+        QReviewExperience rex = QReviewExperience.reviewExperience;
+        QExperienceGroup eg = QExperienceGroup.experienceGroup;
+
+        BooleanBuilder where = new BooleanBuilder();
+        where.and(g.isOpened.isTrue());
+
+        if (jobFieldIds != null && !jobFieldIds.isEmpty()) {
+            where.and(g.guideJobField.id.in(jobFieldIds));
+        }
+
+        if (chatTopicIds != null && !chatTopicIds.isEmpty()) {
+            where.and(gct.chatTopic.id.in(chatTopicIds));
+        }
+
+        if (keyword != null && !keyword.isBlank()) {
+            String like = "%" + keyword.toLowerCase() + "%";
+            where.and(
+                    g.title.lower().like(like)
+                            .or(ht.hashTagName.lower().like(like))
+            );
+        }
+
+        // 리뷰 수 (서브쿼리): 가이드에 귀속된 리뷰 개수
+        var reviewCount = com.querydsl.jpa.JPAExpressions
+                .select(rev.id.count())
+                .from(rev)
+                .join(rev.reservation, res)
+                .where(res.guide.eq(g));
+
+        // 평균 별점 (서브쿼리): 가이드 리뷰의 평균 별점
+        var avgStar = com.querydsl.jpa.JPAExpressions
+                .select(rev.starReview.avg())
+                .from(rev)
+                .join(rev.reservation, res)
+                .where(res.guide.eq(g));
+
+        // 완료된 커피챗 수 (서브쿼리): COMPLETED 상태 예약 수
+        var completedChats = com.querydsl.jpa.JPAExpressions
+                .select(res.id.countDistinct())
+                .from(res)
+                .where(res.guide.eq(g).and(res.status.eq(Status.COMPLETED)));
+
+        // 좋아요 수 (서브쿼리): 해당 가이드의 경험 그룹에 달린 thumbs up 개수
+        var thumbsUpCount = com.querydsl.jpa.JPAExpressions
+                .select(rex.id.count())
+                .from(rex)
+                .join(rex.experienceGroup, eg)
+                .where(eg.guide.eq(g).and(rex.isThumbsUp.isTrue()));
+
+        // content query: 필터를 위한 조인만 하고, 집계는 서브쿼리로 안전하게 계산
+        var contentQuery = queryFactory
+                .select(g, reviewCount, avgStar, completedChats, thumbsUpCount)
+                .from(g)
+                .leftJoin(g.guideJobField, gjf)
+                .leftJoin(g.guideChatTopics, gct)
+                .leftJoin(g.hashTags, ht)
+                .where(where)
+                .groupBy(g.id);
+
+        // 정렬: 인기순이면 리뷰 수 DESC 우선, 아니면 pageable 정렬(기본 modifiedAt DESC)
+        if (orderByReviewCount) {
+            // 서브쿼리는 desc()가 없으므로 명시적으로 OrderSpecifier 사용
+            contentQuery.orderBy(new OrderSpecifier<>(Order.DESC, reviewCount), g.modifiedAt.desc());
+        } else {
+            for (OrderSpecifier<?> orderSpecifier : toOrderSpecifiers(pageable.getSort(), g)) {
+                contentQuery.orderBy(orderSpecifier);
+            }
+        }
+
+        var tuples = pageable.isUnpaged()
+                ? contentQuery.fetch()
+                : contentQuery.offset(pageable.getOffset()).limit(pageable.getPageSize()).fetch();
+
+        List<GuideWithStats> content = new java.util.ArrayList<>(tuples.size());
+        tuples.forEach(t -> {
+            Guide guide = t.get(0, Guide.class);
+            // Hibernate/Dialect에 따라 COUNT/AVG 타입이 BigInteger/Long/BigDecimal/Double 등으로 돌아올 수 있어 Number로 안전 처리
+            Number rcNum = t.get(1, Number.class); // reviewCount
+            Number asNum = t.get(2, Number.class); // avgStar
+            Number ccNum = t.get(3, Number.class); // completedChats
+            Number tuNum = t.get(4, Number.class); // thumbsUpCount
+
+            long rc = rcNum == null ? 0L : rcNum.longValue();
+            long cc = ccNum == null ? 0L : ccNum.longValue();
+            long tu = tuNum == null ? 0L : tuNum.longValue();
+            double avg = asNum == null ? 0.0 : asNum.doubleValue();
+
+            content.add(GuideWithStats.builder()
+                    .guide(guide)
+                    .totalReviews(rc)
+                    .averageStar(avg)
+                    .totalCoffeeChats(cc)
+                    .thumbsUpCount(tu)
+                    .build());
+        });
+
+        long total = Objects.requireNonNullElse(
+                queryFactory
+                        .select(g.id.countDistinct())
+                        .from(g)
+                        .leftJoin(g.guideJobField, gjf)
+                        .leftJoin(g.guideChatTopics, gct)
+                        .leftJoin(g.hashTags, ht)
+                        .where(where)
+                        .fetchFirst(),
+                0L
+        );
+
+        return new PageImpl<>(content, pageable, total);
+    }
+
+    /**
+     * 안전한 정렬 매핑: 허용된 속성만 Q타입으로 매핑한다.
+     * - PathBuilder.get(property) 사용 시 존재하지 않는 프로퍼티/타입 불일치로 런타임 오류가 날 수 있어
+     *   명시적으로 필요한 필드만 처리한다.
+     */
+    private List<OrderSpecifier<?>> toOrderSpecifiers(Sort sort, QGuide g) {
+        List<OrderSpecifier<?>> orders = new ArrayList<>();
+        if (sort == null) return orders;
+
+        for (Sort.Order o : sort) {
+            ComparableExpressionBase<?> expr = switch (o.getProperty()) {
+                case "modifiedAt" -> g.modifiedAt;
+                case "createdAt" -> g.createdAt;
+                case "title" -> g.title;
+                case "approvedDate" -> g.approvedDate;
+                case "companyName" -> g.companyName;
+                default -> null; // 알 수 없는 정렬 키는 무시
+            };
+
+            if (expr != null) {
+                Order direction = o.isAscending() ? Order.ASC : Order.DESC;
+                orders.add(new OrderSpecifier<>(direction, expr));
+            }
+        }
+        return orders;
+    }
+}

--- a/src/main/java/coffeandcommit/crema/domain/guide/repository/GuideWithStats.java
+++ b/src/main/java/coffeandcommit/crema/domain/guide/repository/GuideWithStats.java
@@ -1,0 +1,22 @@
+package coffeandcommit.crema.domain.guide.repository;
+
+import coffeandcommit.crema.domain.guide.entity.Guide;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * Guide 목록 조회 시 함께 가져올 집계 지표 묶음.
+ * - 성능 개선: 가이드당 N회 쿼리 대신 단일 쿼리에서 합산/평균을 계산해 전달한다.
+ */
+@Getter
+@Builder
+@AllArgsConstructor
+public class GuideWithStats {
+    private final Guide guide;
+    private final long totalReviews;
+    private final Double averageStar; // 소수점 한 자리 반올림은 상위 서비스에서 처리
+    private final long totalCoffeeChats; // COMPLETED 상태 예약 수
+    private final long thumbsUpCount; // ReviewExperience 의 isThumbsUp=true 개수
+}
+

--- a/src/main/java/coffeandcommit/crema/domain/reservation/repository/ReservationRepository.java
+++ b/src/main/java/coffeandcommit/crema/domain/reservation/repository/ReservationRepository.java
@@ -16,7 +16,7 @@ import java.util.Collection;
 import java.util.List;
 
 @Repository
-public interface ReservationRepository extends JpaRepository<Reservation, Long> {
+public interface ReservationRepository extends JpaRepository<Reservation, Long>, ReservationRepositoryCustom {
     int countByMember_IdAndStatus(String memberId, Status status);
 
     @EntityGraph(attributePaths = {"guide", "guide.member", "timeUnit"})

--- a/src/main/java/coffeandcommit/crema/domain/reservation/repository/ReservationRepositoryCustom.java
+++ b/src/main/java/coffeandcommit/crema/domain/reservation/repository/ReservationRepositoryCustom.java
@@ -1,0 +1,11 @@
+package coffeandcommit.crema.domain.reservation.repository;
+
+import coffeandcommit.crema.domain.reservation.enums.Status;
+import coffeandcommit.crema.domain.review.dto.response.MyReviewResponseDTO;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface ReservationRepositoryCustom {
+    Page<MyReviewResponseDTO> findMyReviews(String memberId, Status status, String filter, Pageable pageable);
+}
+

--- a/src/main/java/coffeandcommit/crema/domain/reservation/repository/ReservationRepositoryCustom.java
+++ b/src/main/java/coffeandcommit/crema/domain/reservation/repository/ReservationRepositoryCustom.java
@@ -2,10 +2,11 @@ package coffeandcommit.crema.domain.reservation.repository;
 
 import coffeandcommit.crema.domain.reservation.enums.Status;
 import coffeandcommit.crema.domain.review.dto.response.MyReviewResponseDTO;
+import coffeandcommit.crema.domain.review.enums.ReviewWriteFilter;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface ReservationRepositoryCustom {
-    Page<MyReviewResponseDTO> findMyReviews(String memberId, Status status, String filter, Pageable pageable);
+    Page<MyReviewResponseDTO> findMyReviews(String memberId, Status status, ReviewWriteFilter filter, Pageable pageable);
 }
 

--- a/src/main/java/coffeandcommit/crema/domain/reservation/repository/ReservationRepositoryImpl.java
+++ b/src/main/java/coffeandcommit/crema/domain/reservation/repository/ReservationRepositoryImpl.java
@@ -1,0 +1,154 @@
+package coffeandcommit.crema.domain.reservation.repository;
+
+import coffeandcommit.crema.domain.guide.entity.Guide;
+import coffeandcommit.crema.domain.guide.entity.TimeUnit;
+import coffeandcommit.crema.domain.guide.enums.TimeType;
+import coffeandcommit.crema.domain.member.entity.Member;
+import coffeandcommit.crema.domain.reservation.entity.Reservation;
+import coffeandcommit.crema.domain.reservation.enums.Status;
+import coffeandcommit.crema.domain.review.dto.response.GuideInfo;
+import coffeandcommit.crema.domain.review.dto.response.MyReviewResponseDTO;
+import coffeandcommit.crema.domain.review.dto.response.ReservationInfo;
+import coffeandcommit.crema.domain.review.dto.response.ReviewInfo;
+import coffeandcommit.crema.domain.review.entity.Review;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.Tuple;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.PathBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+import jakarta.persistence.EntityManager;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import static coffeandcommit.crema.domain.guide.entity.QTimeUnit.timeUnit;
+import static coffeandcommit.crema.domain.member.entity.QMember.member;
+import static coffeandcommit.crema.domain.reservation.entity.QReservation.reservation;
+import static coffeandcommit.crema.domain.review.entity.QReview.review;
+import static coffeandcommit.crema.domain.guide.entity.QGuide.guide;
+
+public class ReservationRepositoryImpl implements ReservationRepositoryCustom {
+
+    private final EntityManager em;
+    private final JPAQueryFactory queryFactory;
+
+    public ReservationRepositoryImpl(EntityManager em) {
+        this.em = em;
+        this.queryFactory = new JPAQueryFactory(em);
+    }
+
+    @Override
+    public Page<MyReviewResponseDTO> findMyReviews(String memberId, Status status, String filter, Pageable pageable) {
+        BooleanBuilder where = new BooleanBuilder()
+                .and(reservation.member.id.eq(memberId))
+                .and(reservation.status.eq(status));
+
+        if ("WRITTEN".equalsIgnoreCase(filter)) {
+            where.and(review.id.isNotNull());
+        } else if ("NOT_WRITTEN".equalsIgnoreCase(filter)) {
+            where.and(review.id.isNull());
+        }
+
+        List<Tuple> rows = queryFactory
+                .select(
+                        reservation.id,
+                        member.nickname,
+                        member.profileImageUrl,
+                        reservation.matchingTime,
+                        timeUnit.timeType,
+                        review.id,
+                        review.comment,
+                        review.starReview,
+                        review.createdAt
+                )
+                .from(reservation)
+                .leftJoin(review).on(review.reservation.eq(reservation))
+                .leftJoin(reservation.guide, guide)
+                .leftJoin(guide.member, member)
+                .leftJoin(reservation.timeUnit, timeUnit)
+                .where(where)
+                .orderBy(getOrderSpecifiers(pageable.getSort()))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        List<MyReviewResponseDTO> content = new ArrayList<>(rows.size());
+        for (Tuple t : rows) {
+            Long reservationId = t.get(reservation.id);
+            String nickname = t.get(member.nickname);
+            String profileImageUrl = t.get(member.profileImageUrl);
+            LocalDateTime matchingTime = t.get(reservation.matchingTime);
+            TimeType timeType = t.get(timeUnit.timeType);
+
+            Long reviewId = t.get(review.id);
+            String comment = t.get(review.comment);
+            BigDecimal star = t.get(review.starReview);
+            LocalDateTime createdAt = t.get(review.createdAt);
+
+            GuideInfo guideInfo = GuideInfo.builder()
+                    .nickname(nickname)
+                    .profileImageUrl(profileImageUrl)
+                    .build();
+
+            ReservationInfo reservationInfo = ReservationInfo.builder()
+                    .matchingDateTime(matchingTime)
+                    .timeUnit(timeType)
+                    .build();
+
+            ReviewInfo reviewInfo = null;
+            if (reviewId != null) {
+                reviewInfo = ReviewInfo.builder()
+                        .reviewId(reviewId)
+                        .comment(comment != null ? comment : "")
+                        .star(star != null ? star.doubleValue() : null)
+                        .createdAt(createdAt)
+                        .build();
+            }
+
+            content.add(MyReviewResponseDTO.builder()
+                    .reservationId(reservationId)
+                    .guide(guideInfo)
+                    .reservation(reservationInfo)
+                    .review(reviewInfo)
+                    .build());
+        }
+
+        Long total = queryFactory
+                .select(reservation.count())
+                .from(reservation)
+                .leftJoin(review).on(review.reservation.eq(reservation))
+                .where(where)
+                .fetchOne();
+
+        long totalCount = total != null ? total : 0L;
+        return new PageImpl<>(content, pageable, totalCount);
+    }
+
+    private OrderSpecifier<?>[] getOrderSpecifiers(Sort sort) {
+        if (sort == null || sort.isUnsorted()) {
+            return new OrderSpecifier[]{reservation.id.desc()};
+        }
+        PathBuilder<Reservation> entityPath = new PathBuilder<>(Reservation.class, reservation.getMetadata());
+        List<OrderSpecifier<?>> orders = new ArrayList<>();
+        for (Sort.Order o : sort) {
+            try {
+                Order direction = o.isAscending() ? Order.ASC : Order.DESC;
+                orders.add(new OrderSpecifier<>(direction, entityPath.getComparable(o.getProperty(), Comparable.class)));
+            } catch (IllegalArgumentException e) {
+                // 무효한 정렬 필드는 무시하고 기본 정렬 사용
+            }
+        }
+        if (orders.isEmpty()) {
+            return new OrderSpecifier[]{reservation.id.desc()};
+        }
+        return orders.toArray(new OrderSpecifier<?>[0]);
+    }
+}

--- a/src/main/java/coffeandcommit/crema/domain/reservation/repository/ReservationRepositoryImpl.java
+++ b/src/main/java/coffeandcommit/crema/domain/reservation/repository/ReservationRepositoryImpl.java
@@ -1,16 +1,12 @@
 package coffeandcommit.crema.domain.reservation.repository;
 
-import coffeandcommit.crema.domain.guide.entity.Guide;
-import coffeandcommit.crema.domain.guide.entity.TimeUnit;
 import coffeandcommit.crema.domain.guide.enums.TimeType;
-import coffeandcommit.crema.domain.member.entity.Member;
 import coffeandcommit.crema.domain.reservation.entity.Reservation;
 import coffeandcommit.crema.domain.reservation.enums.Status;
 import coffeandcommit.crema.domain.review.dto.response.GuideInfo;
 import coffeandcommit.crema.domain.review.dto.response.MyReviewResponseDTO;
 import coffeandcommit.crema.domain.review.dto.response.ReservationInfo;
 import coffeandcommit.crema.domain.review.dto.response.ReviewInfo;
-import coffeandcommit.crema.domain.review.entity.Review;
 import coffeandcommit.crema.domain.review.enums.ReviewWriteFilter;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.Tuple;

--- a/src/main/java/coffeandcommit/crema/domain/reservation/repository/ReservationRepositoryImpl.java
+++ b/src/main/java/coffeandcommit/crema/domain/reservation/repository/ReservationRepositoryImpl.java
@@ -11,6 +11,7 @@ import coffeandcommit.crema.domain.review.dto.response.MyReviewResponseDTO;
 import coffeandcommit.crema.domain.review.dto.response.ReservationInfo;
 import coffeandcommit.crema.domain.review.dto.response.ReviewInfo;
 import coffeandcommit.crema.domain.review.entity.Review;
+import coffeandcommit.crema.domain.review.enums.ReviewWriteFilter;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.Tuple;
 import com.querydsl.core.types.Order;
@@ -46,14 +47,14 @@ public class ReservationRepositoryImpl implements ReservationRepositoryCustom {
     }
 
     @Override
-    public Page<MyReviewResponseDTO> findMyReviews(String memberId, Status status, String filter, Pageable pageable) {
+    public Page<MyReviewResponseDTO> findMyReviews(String memberId, Status status, ReviewWriteFilter filter, Pageable pageable) {
         BooleanBuilder where = new BooleanBuilder()
                 .and(reservation.member.id.eq(memberId))
                 .and(reservation.status.eq(status));
 
-        if ("WRITTEN".equalsIgnoreCase(filter)) {
+        if (filter == ReviewWriteFilter.WRITTEN) {
             where.and(review.id.isNotNull());
-        } else if ("NOT_WRITTEN".equalsIgnoreCase(filter)) {
+        } else if (filter == ReviewWriteFilter.NOT_WRITTEN) {
             where.and(review.id.isNull());
         }
 

--- a/src/main/java/coffeandcommit/crema/domain/review/controller/ReviewController.java
+++ b/src/main/java/coffeandcommit/crema/domain/review/controller/ReviewController.java
@@ -71,7 +71,7 @@ public class ReviewController {
 
         Response<Page<MyReviewResponseDTO>> response = Response.<Page<MyReviewResponseDTO>>builder()
                 .message("내 리뷰 조회 성공")
-                .data(result)
+                .data(result.isEmpty() ? null : result)
                 .build();
 
         return ResponseEntity.ok(response);

--- a/src/main/java/coffeandcommit/crema/domain/review/enums/ReviewWriteFilter.java
+++ b/src/main/java/coffeandcommit/crema/domain/review/enums/ReviewWriteFilter.java
@@ -1,0 +1,23 @@
+package coffeandcommit.crema.domain.review.enums;
+
+public enum ReviewWriteFilter {
+    ALL,
+    WRITTEN,
+    NOT_WRITTEN;
+
+    public static ReviewWriteFilter from(String value) {
+        if (value == null || value.isBlank()) return ALL;
+        switch (value.trim().toUpperCase()) {
+            case "WRITTEN":
+                return WRITTEN;
+            case "NOT_WRITTEN":
+                return NOT_WRITTEN;
+            case "ALL":
+                return ALL;
+            default:
+                // 무효 값은 ALL로 처리하거나, 정책상 예외를 던질 수 있음
+                return ALL;
+        }
+    }
+}
+

--- a/src/main/java/coffeandcommit/crema/domain/review/service/ReviewService.java
+++ b/src/main/java/coffeandcommit/crema/domain/review/service/ReviewService.java
@@ -111,27 +111,13 @@ public class ReviewService {
     /* 내 리뷰 조회 */
     @Transactional(readOnly = true)
     public Page<MyReviewResponseDTO> getMyReviews(String loginMemberId, String filter, Pageable pageable) {
+        Page<MyReviewResponseDTO> page = reservationRepository.findMyReviews(
+                loginMemberId,
+                Status.COMPLETED,
+                filter,
+                pageable
+        );
 
-        Page<Reservation> reservations;
-
-        if ("WRITTEN".equalsIgnoreCase(filter)) {
-            reservations = reservationRepository.findWrittenByMember(loginMemberId, Status.COMPLETED, pageable);
-        } else if ("NOT_WRITTEN".equalsIgnoreCase(filter)) {
-            reservations = reservationRepository.findNotWrittenByMember(loginMemberId, Status.COMPLETED, pageable);
-        } else { // 기본: ALL
-            reservations = reservationRepository.findByMember_IdAndStatus(loginMemberId, Status.COMPLETED, pageable);
-        }
-
-        if (reservations.isEmpty()) {
-            throw new BaseException(ErrorStatus.RESERVATION_NOT_FOUND);
-        }
-
-        // 리뷰 bulk 조회
-        List<Long> reservationIds = reservations.stream().map(Reservation::getId).toList();
-        Map<Long, Review> reviewMap = reviewRepository.findByReservationIdIn(reservationIds).stream()
-                .collect(Collectors.toMap(r -> r.getReservation().getId(), r -> r));
-
-        return reservations.map(reservation ->
-                MyReviewResponseDTO.from(reservation, reviewMap.get(reservation.getId())));
+        return page;
     }
 }

--- a/src/main/java/coffeandcommit/crema/domain/review/service/ReviewService.java
+++ b/src/main/java/coffeandcommit/crema/domain/review/service/ReviewService.java
@@ -23,9 +23,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 
 @Slf4j
 @Service

--- a/src/main/java/coffeandcommit/crema/domain/review/service/ReviewService.java
+++ b/src/main/java/coffeandcommit/crema/domain/review/service/ReviewService.java
@@ -111,10 +111,11 @@ public class ReviewService {
     /* 내 리뷰 조회 */
     @Transactional(readOnly = true)
     public Page<MyReviewResponseDTO> getMyReviews(String loginMemberId, String filter, Pageable pageable) {
+        var effectiveFilter = coffeandcommit.crema.domain.review.enums.ReviewWriteFilter.from(filter);
         Page<MyReviewResponseDTO> page = reservationRepository.findMyReviews(
                 loginMemberId,
                 Status.COMPLETED,
-                filter,
+                effectiveFilter,
                 pageable
         );
 

--- a/src/main/java/coffeandcommit/crema/global/httpTest/GuideMeService.http
+++ b/src/main/java/coffeandcommit/crema/global/httpTest/GuideMeService.http
@@ -11,7 +11,7 @@ POST http://localhost:8080/api/test/auth/login
 Content-Type: application/json
 
 {
-  "nickname": "guide_2b2a553d"
+  "nickname": "guide_69c286fd"
 }
 
 ### 7. 가이드 경험 등록 (enum 기반, 새로운 스펙)
@@ -44,7 +44,7 @@ DELETE http://localhost:8080/api/test/auth/cleanup
 
 ### 6. 가이드 본인 프로필 조회
 GET http://localhost:8080/api/guides
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiI0NTM2ZjBjYiIsInR5cGUiOiJhY2Nlc3MiLCJqdGkiOiI1YWU3OGUzNi0zN2ZjLTQ5ZjItYTZlYy0yOWRhNmIzOWZhNmIiLCJpYXQiOjE3NTc0Nzk5NjEsImV4cCI6MTc1NzQ4MTc2MX0.AmBGY6o2yWpgUBcwiqkDKkxoPbbNFRhdN086J_bpG93hMTrEP3Sxwk1g5DbuSYul50BNVIPYdNXiv64GmMuMmw
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJlNjBkNTIxMSIsInR5cGUiOiJhY2Nlc3MiLCJqdGkiOiI5ZDkyNDRiNi1lYzk3LTQ0ZTUtYmMyMC0xZDcwZmI2MGE4NWQiLCJpYXQiOjE3NTc3OTk3MDQsImV4cCI6MTc1NzgwMTUwNH0.TR6oHbGiTxntnJ0mdTEH9eCSRUMmegfgS8pLb8q4wgwUG0kCt5bTPRvI0pHcNezbyw35-HoYyOpcioyEt4Hffg
 
 ### 가이드 조회 (jobFieldIds, keyword 쿼리 파라미터)
 GET http://localhost:8080/api/guides?jobFieldIds=PLANNING_STRATEGY

--- a/src/main/java/coffeandcommit/crema/global/httpTest/GuidesAndReviews.http
+++ b/src/main/java/coffeandcommit/crema/global/httpTest/GuidesAndReviews.http
@@ -1,0 +1,53 @@
+### 테스트 계정 생성 (선택)
+POST http://localhost:8080/api/test/auth/create-rookie
+Content-Type: application/json
+
+### 테스트 계정 로그인 (아래 nickname에 위에서 생성된 닉네임을 입력)
+POST http://localhost:8080/api/test/auth/login
+Content-Type: application/json
+
+{
+  "nickname": "guide_69c286fd"
+}
+
+### 아래 요청들에서 Authorization 헤더의 ~~~ 부분을 3번의 accessToken으로 교체해서 사용하세요.
+
+### Guides - 기본 목록 (latest, 무필터)
+GET http://localhost:8080/api/guides?page=0&size=10&sort=latest
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJlNjBkNTIxMSIsInR5cGUiOiJhY2Nlc3MiLCJqdGkiOiJhMjQ2MGQ1Ny1jMWI3LTRmZDktODM3ZS1hMDMxMjdhYTRiZTciLCJpYXQiOjE3NTc4MDM0OTUsImV4cCI6MTc1NzgwNTI5NX0.RHceh_sGwsNTRTouoeZp_nzJPlHgqV42XYAN3OrDNW64rbeJpdH04ZUhRgHiPNsB9IwdcmfqDj2-p4b-CrRA3g
+
+### Guides - 키워드 접두어 검색 + 이스케이프 확인 (%, _, \ 포함)
+# 예: 키워드에 특수문자 포함 시 정상 동작/오버매칭 방지 확인
+GET http://localhost:8080/api/guides?keyword=Java%25_dev\_tips&page=0&size=10
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJlNjBkNTIxMSIsInR5cGUiOiJhY2Nlc3MiLCJqdGkiOiJhMjQ2MGQ1Ny1jMWI3LTRmZDktODM3ZS1hMDMxMjdhYTRiZTciLCJpYXQiOjE3NTc4MDM0OTUsImV4cCI6MTc1NzgwNTI5NX0.RHceh_sGwsNTRTouoeZp_nzJPlHgqV42XYAN3OrDNW64rbeJpdH04ZUhRgHiPNsB9IwdcmfqDj2-p4b-CrRA3g
+
+### Guides - 직무 필터 (JobNameType)
+# 예시: IT_DEVELOPMENT_DATA, PLANNING_STRATEGY 등
+GET http://localhost:8080/api/guides?jobNames=IT_DEVELOPMENT_DATA&page=0&size=10
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJlNjBkNTIxMSIsInR5cGUiOiJhY2Nlc3MiLCJqdGkiOiJhMjQ2MGQ1Ny1jMWI3LTRmZDktODM3ZS1hMDMxMjdhYTRiZTciLCJpYXQiOjE3NTc4MDM0OTUsImV4cCI6MTc1NzgwNTI5NX0.RHceh_sGwsNTRTouoeZp_nzJPlHgqV42XYAN3OrDNW64rbeJpdH04ZUhRgHiPNsB9IwdcmfqDj2-p4b-CrRA3g
+
+### Guides - 챗 토픽 필터 (TopicNameType)
+# 예시: INTERVIEW, PORTFOLIO, COVER_LETTER 등
+GET http://localhost:8080/api/guides?chatTopicNames=INTERVIEW&page=0&size=10
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJlNjBkNTIxMSIsInR5cGUiOiJhY2Nlc3MiLCJqdGkiOiJhMjQ2MGQ1Ny1jMWI3LTRmZDktODM3ZS1hMDMxMjdhYTRiZTciLCJpYXQiOjE3NTc4MDM0OTUsImV4cCI6MTc1NzgwNTI5NX0.RHceh_sGwsNTRTouoeZp_nzJPlHgqV42XYAN3OrDNW64rbeJpdH04ZUhRgHiPNsB9IwdcmfqDj2-p4b-CrRA3g
+
+### Guides - popular 정렬 (메모리 정렬 후 재페이징)
+GET http://localhost:8080/api/guides?page=0&size=10&sort=popular
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJlNjBkNTIxMSIsInR5cGUiOiJhY2Nlc3MiLCJqdGkiOiJhMjQ2MGQ1Ny1jMWI3LTRmZDktODM3ZS1hMDMxMjdhYTRiZTciLCJpYXQiOjE3NTc4MDM0OTUsImV4cCI6MTc1NzgwNTI5NX0.RHceh_sGwsNTRTouoeZp_nzJPlHgqV42XYAN3OrDNW64rbeJpdH04ZUhRgHiPNsB9IwdcmfqDj2-p4b-CrRA3g
+
+### Reviews - 내 리뷰 조회 ALL (기본)
+GET http://localhost:8080/api/reviews/me?filter=ALL&page=0&size=10
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJlNjBkNTIxMSIsInR5cGUiOiJhY2Nlc3MiLCJqdGkiOiJhMjQ2MGQ1Ny1jMWI3LTRmZDktODM3ZS1hMDMxMjdhYTRiZTciLCJpYXQiOjE3NTc4MDM0OTUsImV4cCI6MTc1NzgwNTI5NX0.RHceh_sGwsNTRTouoeZp_nzJPlHgqV42XYAN3OrDNW64rbeJpdH04ZUhRgHiPNsB9IwdcmfqDj2-p4b-CrRA3g
+
+### Reviews - 내 리뷰 조회 WRITTEN (작성한 리뷰만)
+GET http://localhost:8080/api/reviews/me?filter=WRITTEN&page=0&size=10
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJlNjBkNTIxMSIsInR5cGUiOiJhY2Nlc3MiLCJqdGkiOiJhMjQ2MGQ1Ny1jMWI3LTRmZDktODM3ZS1hMDMxMjdhYTRiZTciLCJpYXQiOjE3NTc4MDM0OTUsImV4cCI6MTc1NzgwNTI5NX0.RHceh_sGwsNTRTouoeZp_nzJPlHgqV42XYAN3OrDNW64rbeJpdH04ZUhRgHiPNsB9IwdcmfqDj2-p4b-CrRA3g
+
+### Reviews - 내 리뷰 조회 NOT_WRITTEN (미작성 리뷰만)
+GET http://localhost:8080/api/reviews/me?filter=NOT_WRITTEN&page=0&size=10
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJlNjBkNTIxMSIsInR5cGUiOiJhY2Nlc3MiLCJqdGkiOiJhMjQ2MGQ1Ny1jMWI3LTRmZDktODM3ZS1hMDMxMjdhYTRiZTciLCJpYXQiOjE3NTc4MDM0OTUsImV4cCI6MTc1NzgwNTI5NX0.RHceh_sGwsNTRTouoeZp_nzJPlHgqV42XYAN3OrDNW64rbeJpdH04ZUhRgHiPNsB9IwdcmfqDj2-p4b-CrRA3g
+
+### Reviews - 무효 필터 값 (lenient: ALL로 동작)
+GET http://localhost:8080/api/reviews/me?filter=INVALID&page=0&size=10
+Authorization: Bearer ~~~
+

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -11,3 +11,11 @@ spring:
     gcp:
       credentials:
         location: "${GCP_CREDENTIALS_JSON_PATH}"
+  # init.sql 자동 실행 설정 (로컬 전용)
+  sql:
+    init:
+      mode: always
+      data-locations: classpath:init.sql
+      continue-on-error: true
+  jpa:
+    defer-datasource-initialization: true


### PR DESCRIPTION
# 🚀 What’s this PR about?

- QueryDLS 도입

# 🛠️ What’s been done?

- EXISTS 기반 필터링
    - 직무/주제/태그 조건을 메인 쿼리의 조인 대신 EXISTS (subquery)로 처리.
    - 효과: 행 증식 방지, 페이징/정렬 단계의 불필요한 중복 제거, DISTINCT 의존도 감소.
 - 불필요 조인 제거
    - 메인 조회 쿼리에서 leftJoin(g.guideJobField, ...) 제거.
    - 효과: 스캔/정렬/페이징 비용 감소, 카운트 쿼리 단순화에 직접 기여.
- 인덱스 친화적 LIKE
    - lower(column).like(?) → column like 'prefix%'로 변경.
    - 효과: 함수 적용으로 인덱스 무력화되는 문제 제거, guide.title/hash_tag.hash_tag_name의 Prefix-LIKE 인덱스 활용 가능.
    - 전제: DB 콜레이션이 대소문자 비구분(기본)일 때 동일 검색 품질 유지.
- 카운트 쿼리 최적화
    - countDistinct + 조인 → count([[g.id](http://g.id/)](http://g.id/)) 단순화, 조인 제거.
    - 효과: 전체 건수 계산 비용 대폭 감소.

# 🧪 Testing Details

- X

# 👀 Checkpoints for Reviewers

- X

# 📚 References & Resources

- X

# 🎯 Related Issues

- close#103 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 가이드 목록 조회에 필터(직무/주제/키워드), 정렬, 페이지네이션 동작 고도화
  - 내 리뷰 조회에 상태/작성여부 필터와 정렬, 페이지네이션 지원

- 문서
  - 가이드 목록 조회 API 설명과 요약 추가

- 리팩터링
  - 검색·조회 로직을 커스텀 저장소로 분리해 성능과 정렬 처리 개선
  - 내 리뷰 DTO 구성 책임을 서비스에서 저장소 계층으로 이관

- 잡무
  - 프런트엔드 개발용 목업 데이터 추가
  - 로컬 환경 초기 SQL 데이터 자동 로드 설정
  - HTTP 테스트 자격 정보 갱신

<!-- end of auto-generated comment: release notes by coderabbit.ai -->