### PR TITLE
[Fix] 멤버에서 가이드 업그레이드에서 업로드한 pdf 조회 시 presigned url 사용하게 변경

### DIFF
--- a/src/main/java/coffeandcommit/crema/domain/member/service/MemberService.java
+++ b/src/main/java/coffeandcommit/crema/domain/member/service/MemberService.java
@@ -412,6 +412,13 @@ public class MemberService {
             certificationPdfUrl = storageService.generateViewUrl(guide.getCertificationImageUrl());
         }
 
+        // workingPeriod 계산
+        String workingPeriod = calculateWorkingPeriodDisplay(
+                guide.getWorkingStart(),
+                guide.getWorkingEnd(),
+                guide.isCurrent()
+        );
+
         return MemberUpgradeResponse.builder()
                 .companyName(guide.getCompanyName())
                 .isCompanyNamePublic(guide.isCompanyNamePublic())
@@ -419,6 +426,7 @@ public class MemberService {
                 .isCurrent(guide.isCurrent())
                 .workingStart(guide.getWorkingStart())
                 .workingEnd(guide.getWorkingEnd())
+                .workingPeriod(workingPeriod)
                 .certificationPdfUrl(certificationPdfUrl) // presigned URL 반환
                 .build();
     }

--- a/src/test/java/coffeandcommit/crema/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/coffeandcommit/crema/domain/member/controller/MemberControllerTest.java
@@ -80,7 +80,7 @@ class MemberControllerTest {
                 .jobPosition("개발자")
                 .isCurrent(true)
                 .workingStart(LocalDate.of(2022, 1, 1))
-                .workingPeriod("2년 3개월")
+                .workingPeriod("2022.01 ~ 재직중")
                 .certificationPdfUrl("https://example.com/cert.pdf")
                 .build();
 

--- a/src/test/java/coffeandcommit/crema/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/coffeandcommit/crema/domain/member/controller/MemberControllerTest.java
@@ -358,18 +358,19 @@ class MemberControllerTest {
         @DisplayName("성공: 가이드 업그레이드 정보 조회")
         void getUpgradeInfo_Success() {
             // given
-            given(memberService.getUpgradeInfo("testId")).willReturn(testMemberUpgradeResponse);
+            MemberUpgradeResponse response = MemberUpgradeResponse.builder()
+                    .companyName("테스트회사")
+                    .jobPosition("개발자")
+                    .certificationPdfUrl("https://storage.googleapis.com/bucket/file?X-Goog-Signature=presigned") // presigned URL
+                    .build();
+
+            given(memberService.getUpgradeInfo("testId")).willReturn(response);
 
             // when
-            ApiResponse<MemberUpgradeResponse> response = memberController.getUpgradeInfo(testUserDetails);
+            ApiResponse<MemberUpgradeResponse> result = memberController.getUpgradeInfo(testUserDetails);
 
             // then
-            assertThat(response).isNotNull();
-            assertThat(response.isSuccess()).isTrue();
-            assertThat(response.getResult().getCompanyName()).isEqualTo("테스트회사");
-            assertThat(response.getResult().getJobPosition()).isEqualTo("개발자");
-
-            verify(memberService).getUpgradeInfo("testId");
+            assertThat(result.getResult().getCertificationPdfUrl()).contains("X-Goog-Signature");
         }
 
         @Test

--- a/src/test/java/coffeandcommit/crema/domain/member/service/MemberCoffeeChatServiceTest.java
+++ b/src/test/java/coffeandcommit/crema/domain/member/service/MemberCoffeeChatServiceTest.java
@@ -21,7 +21,6 @@ import coffeandcommit.crema.domain.reservation.enums.Status;
 import coffeandcommit.crema.domain.reservation.repository.ReservationRepository;
 import coffeandcommit.crema.global.common.exception.BaseException;
 import coffeandcommit.crema.global.common.exception.code.ErrorStatus;
-import coffeandcommit.crema.domain.guide.enums.TimeType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;

--- a/src/test/java/coffeandcommit/crema/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/coffeandcommit/crema/domain/member/service/MemberServiceTest.java
@@ -139,7 +139,7 @@ class MemberServiceTest {
                 .jobPosition("개발자")
                 .isCurrent(true)
                 .workingStart(LocalDate.of(2022, 1, 1))
-                .workingPeriod("2년 3개월")
+                .workingPeriod("2022.01 ~ 재직중")
                 .certificationPdfUrl("https://storage.googleapis.com/bucket/file?X-Goog-Signature=...")
                 .build();
 

--- a/src/test/java/coffeandcommit/crema/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/coffeandcommit/crema/domain/member/service/MemberServiceTest.java
@@ -109,7 +109,7 @@ class MemberServiceTest {
                 .workingStart(LocalDate.of(2022, 1, 1))
                 .isCurrent(true)
                 .isCompanyNamePublic(true)
-                .certificationImageUrl("https://example.com/cert.pdf")
+                .certificationImageUrl("certification-pdfs/guideId_cert.pdf")
                 .build();
 
         // 테스트용 응답 DTO
@@ -140,7 +140,7 @@ class MemberServiceTest {
                 .isCurrent(true)
                 .workingStart(LocalDate.of(2022, 1, 1))
                 .workingPeriod("2년 3개월")
-                .certificationPdfUrl("https://example.com/cert.pdf")
+                .certificationPdfUrl("https://storage.googleapis.com/bucket/file?X-Goog-Signature=...")
                 .build();
 
         // 테스트용 업그레이드 요청
@@ -328,34 +328,27 @@ class MemberServiceTest {
     class GuideUpgradeTests {
 
         @Test
-        @DisplayName("성공: 가이드 업그레이드")
+        @DisplayName("성공: 멤버를 가이드로 업그레이드")
         void upgradeToGuide_Success() {
             // given
-            given(memberRepository.findByIdAndIsDeletedFalse("testId"))
-                    .willReturn(Optional.of(testMember));
-            given(guideRepository.findByMember_Id("testId"))
-                    .willReturn(Optional.empty());
-            given(fileService.uploadFile(eq(testPdfFile), eq(FileType.PDF), anyString(), eq("testId")))
+            given(memberRepository.findByIdAndIsDeletedFalse("testId")).willReturn(Optional.of(testMember));
+            given(fileService.uploadFile(any(), eq(FileType.PDF), eq("certification-pdfs"), eq("testId")))
                     .willReturn(FileUploadResponse.builder()
-                            .fileKey("cert.pdf")
-                            .fileUrl("https://example.com/cert.pdf")
-                            .build()
-                    );
-            given(guideRepository.save(any(Guide.class)))
-                    .willReturn(testGuideEntity);
-            given(memberRepository.save(any(Member.class)))
-                    .willReturn(testGuide);
+                            .fileKey("certification-pdfs/testId_cert.pdf")
+                            .fileUrl("https://storage.googleapis.com/bucket/certification-pdfs/testId_cert.pdf")
+                            .build());
+            given(memberRepository.save(any(Member.class))).willReturn(testGuide);
+            given(guideRepository.save(any(Guide.class))).willReturn(testGuideEntity);
+            given(storageService.generateViewUrl("certification-pdfs/guideId_cert.pdf"))
+                    .willReturn("https://storage.googleapis.com/bucket/file?X-Goog-Signature=presigned");
 
             // when
             MemberUpgradeResponse result = memberService.upgradeToGuide("testId", testUpgradeRequest, testPdfFile);
 
             // then
             assertThat(result).isNotNull();
-            verify(memberRepository).findByIdAndIsDeletedFalse("testId");
-            verify(guideRepository).findByMember_Id("testId");
-            verify(fileService).uploadFile(eq(testPdfFile), eq(FileType.PDF), anyString(), eq("testId"));
-            verify(guideRepository).save(any(Guide.class));
-            verify(memberRepository).save(any(Member.class));
+            assertThat(result.getCertificationPdfUrl()).contains("X-Goog-Signature"); // presigned URL 확인
+            verify(storageService).generateViewUrl(any(String.class));
         }
 
         @Test
@@ -462,18 +455,18 @@ class MemberServiceTest {
         @DisplayName("성공: 가이드 업그레이드 정보 조회")
         void getUpgradeInfo_Success() {
             // given
-            given(memberRepository.findByIdAndIsDeletedFalse("testId"))
-                    .willReturn(Optional.of(testGuide));
-            given(guideRepository.findByMember_Id("testId"))
-                    .willReturn(Optional.of(testGuideEntity));
+            given(memberRepository.findByIdAndIsDeletedFalse("guideId")).willReturn(Optional.of(testGuide));
+            given(guideRepository.findByMember_Id("guideId")).willReturn(Optional.of(testGuideEntity));
+            given(storageService.generateViewUrl("certification-pdfs/guideId_cert.pdf"))
+                    .willReturn("https://storage.googleapis.com/bucket/file?X-Goog-Signature=presigned");
 
             // when
-            MemberUpgradeResponse result = memberService.getUpgradeInfo("testId");
+            MemberUpgradeResponse result = memberService.getUpgradeInfo("guideId");
 
             // then
             assertThat(result).isNotNull();
-            verify(memberRepository).findByIdAndIsDeletedFalse("testId");
-            verify(guideRepository).findByMember_Id("testId");
+            assertThat(result.getCertificationPdfUrl()).contains("X-Goog-Signature");
+            verify(storageService).generateViewUrl("certification-pdfs/guideId_cert.pdf");
         }
 
         @Test


### PR DESCRIPTION
# 🚀 What’s this PR about?
- 멤버에서 가이드 업그레이드에서 업로드한 pdf 조회 시 presigned url 사용하게 변경

# 🛠️ What’s been done?
- 기존엔 presigned url이 아니라 그냥 직접 url 반환하던 것을 수정

# 🧪 Testing Details
<img width="2144" height="2334" alt="스크린샷 2025-09-14 오전 6 54 14" src="https://github.com/user-attachments/assets/df93d28d-b186-4cc2-b83f-3fb880905818" />

# 🎯 Related Issues
closes #151 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 가이드 인증서 PDF를 presigned URL로 제공하여 보다 안전하게 열람 가능
- 리팩터링
  - 인증서 PDF 저장 방식을 직접 URL에서 파일 키 기반으로 전환
  - 업로드/삭제/갱신 로직을 파일 키 중심으로 통합
  - 저장 경로를 certification-pdfs 디렉터리로 정리하고 유효성 검증·로그 개선
- 테스트
  - 업그레이드 정보 응답에서 presigned URL을 검증하도록 테스트 수정
  - 불필요한 임포트 제거 및 테스트 데이터/스텁을 파일 키·presigned URL 흐름에 맞게 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->