### PR TITLE
QA 리팩토링

### DIFF
--- a/src/main/java/coffeandcommit/crema/domain/guide/dto/request/GuideVisibilityRequestDTO.java
+++ b/src/main/java/coffeandcommit/crema/domain/guide/dto/request/GuideVisibilityRequestDTO.java
@@ -5,11 +5,13 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
+@Setter
 public class GuideVisibilityRequestDTO {
 
     @JsonProperty("isOpened")

--- a/src/main/java/coffeandcommit/crema/domain/guide/service/GuideMeService.java
+++ b/src/main/java/coffeandcommit/crema/domain/guide/service/GuideMeService.java
@@ -589,6 +589,9 @@ public class GuideMeService {
 
         guide.updateVisibility(guideVisibilityRequestDTO.isOpened());
 
+        // 명시적 저장으로 즉시 더티체킹 반영 보장
+        guideRepository.save(guide);
+
     }
 
     /* 가이드 전체 예약 조회 (페이징) */

--- a/src/main/java/coffeandcommit/crema/domain/guide/service/GuideMeService.java
+++ b/src/main/java/coffeandcommit/crema/domain/guide/service/GuideMeService.java
@@ -588,9 +588,8 @@ public class GuideMeService {
                 .orElseThrow(() -> new BaseException(ErrorStatus.GUIDE_NOT_FOUND));
 
         guide.updateVisibility(guideVisibilityRequestDTO.isOpened());
-
-        // 명시적 저장으로 즉시 더티체킹 반영 보장
-        guideRepository.save(guide);
+        // 즉시 DB 반영 필요시 명시적 flush
+        guideRepository.saveAndFlush(guide);
 
     }
 

--- a/src/main/java/coffeandcommit/crema/domain/reservation/service/ReservationService.java
+++ b/src/main/java/coffeandcommit/crema/domain/reservation/service/ReservationService.java
@@ -61,13 +61,18 @@ public class ReservationService {
         Member member = memberRepository.findById(loginMemberId)
                 .orElseThrow(() -> new BaseException(ErrorStatus.MEMBER_NOT_FOUND));
 
-        // 2. 존재하는 가이드인지 확인
+        // 2. 존재하는가이드인지확인
         Guide guide = guideRepository.findById(reservationRequestDTO.getGuideId())
                 .orElseThrow(() -> new BaseException(ErrorStatus.GUIDE_NOT_FOUND));
 
+        // 2-00. 비공개가이드신청차단
+        if (!guide.isOpened()) {
+            throw new BaseException(ErrorStatus.GUIDE_NOT_OPENED);
+        }
+
         // 2-0. 자기 자신에게 신청 방지
         if (guide.getMember() != null && guide.getMember().getId().equals(member.getId())) {
-            throw new BaseException(ErrorStatus.FORBIDDEN);
+            throw new BaseException(ErrorStatus.SELF_RESERVATION_NOT_ALLOWED);
         }
 
         // 2-1. 포인트 선검증: 신청하려는 시간 단위 가격보다 보유 포인트가 적으면 신청 불가
@@ -80,13 +85,18 @@ public class ReservationService {
         if (currentPoint < price) {
             throw new BaseException(ErrorStatus.INSUFFICIENT_POINTS);
         }
-        // 포인트 이체는 가이드가 수락(confirmed)할 때 수행
+        // 포인트이체는가이드가수락(confirmed)할때수행
 
-        // 3. Survey 엔티티 생성
+        // 3. Survey 엔티티생성
+        var surveyReq = reservationRequestDTO.getSurvey();
+        if (surveyReq == null || surveyReq.getPreferredDate() == null) {
+            // 적절한에러코드로교체필요: 예) ErrorStatus.INVALID_SURVEY
+            throw new BaseException(ErrorStatus.INVALID_SURVEY);
+        }
         Survey survey = Survey.builder()
                 .fileUploadURL("")
-                .messageToGuide(reservationRequestDTO.getSurvey().getMessageToGuide())
-                .preferredDate(reservationRequestDTO.getSurvey().getPreferredDate())
+                .messageToGuide(surveyReq.getMessageToGuide())
+                .preferredDate(surveyReq.getPreferredDate())
                 .build();
 
         // 3-1. 파일 업로드 처리 (files가 존재하는 경우만)
@@ -119,7 +129,7 @@ public class ReservationService {
                 .survey(survey)
                 .build();
 
-        // 5. TimeUnit 엔티티 생성 (예약 ↔ 시간 단위 연결)
+        // 5. TimeUnit 엔티티생성 (예약↔시간단위연결)
         TimeUnit timeUnit = TimeUnit.builder()
                 .reservation(reservation)
                 .timeType(requestTimeType)

--- a/src/main/java/coffeandcommit/crema/global/common/exception/code/ErrorStatus.java
+++ b/src/main/java/coffeandcommit/crema/global/common/exception/code/ErrorStatus.java
@@ -53,6 +53,8 @@ public enum ErrorStatus implements BaseCode {
     GUIDE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 가이드를 찾을 수 없습니다."),
     NO_GUIDES_FOUND(HttpStatus.NOT_FOUND, "조건에 맞는 가이드를 찾을 수 없습니다."),
     GUIDE_JOB_FIELD_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 가이드의 직무 분야를 찾을 수 없습니다."),
+    GUIDE_NOT_OPENED(HttpStatus.FORBIDDEN, "비공개 가이드입니다. 신청할 수 없습니다."),
+    SELF_RESERVATION_NOT_ALLOWED(HttpStatus.FORBIDDEN, "본인에게는 커피챗을 신청할 수 없습니다."),
     INVALID_JOB_FIELD(HttpStatus.BAD_REQUEST, "잘못된 직무 분야 요청입니다."),
     INVALID_TOPIC(HttpStatus.BAD_REQUEST, "잘못된 주제 요청입니다."),
     MAX_TOPIC_EXCEEDED(HttpStatus.BAD_REQUEST, "등록 가능한 주제 개수를 초과했습니다."),
@@ -101,6 +103,7 @@ public enum ErrorStatus implements BaseCode {
     INVALID_STATUS(HttpStatus.CONFLICT,"잘못된 예약 상태 요청입니다."),
     ALREADY_DECIDED(HttpStatus.CONFLICT,"이미 처리된 예약입니다."),
     INVALID_TIME_UNIT(HttpStatus.BAD_REQUEST, "유효하지 않은 시간 단위입니다."),
+    INVALID_SURVEY(HttpStatus.BAD_REQUEST, "유효하지 않은 사전 정보입니다."),
     SURVEY_NOT_FOUND(HttpStatus.NOT_FOUND, "등록된 사전 정보가 없습니다.");
 
 

--- a/src/main/java/coffeandcommit/crema/global/httpTest/GuidesAndReviews.http
+++ b/src/main/java/coffeandcommit/crema/global/httpTest/GuidesAndReviews.http
@@ -7,7 +7,7 @@ POST http://localhost:8080/api/test/auth/login
 Content-Type: application/json
 
 {
-  "nickname": "guide_69c286fd"
+  "nickname": "guide_cdcc2689"
 }
 
 ### 아래 요청들에서 Authorization 헤더의 ~~~ 부분을 3번의 accessToken으로 교체해서 사용하세요.
@@ -35,6 +35,24 @@ Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJlNjBkNTIxMSIsInR5cGUiOiJhY
 GET http://localhost:8080/api/guides?page=0&size=10&sort=popular
 Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJlNjBkNTIxMSIsInR5cGUiOiJhY2Nlc3MiLCJqdGkiOiJhMjQ2MGQ1Ny1jMWI3LTRmZDktODM3ZS1hMDMxMjdhYTRiZTciLCJpYXQiOjE3NTc4MDM0OTUsImV4cCI6MTc1NzgwNTI5NX0.RHceh_sGwsNTRTouoeZp_nzJPlHgqV42XYAN3OrDNW64rbeJpdH04ZUhRgHiPNsB9IwdcmfqDj2-p4b-CrRA3g
 
+### Guides - 내 가이드 공개 상태 OFF
+PATCH http://localhost:8080/api/guides/me/visibility
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJkMmViMzkyNSIsInR5cGUiOiJhY2Nlc3MiLCJqdGkiOiI2NzJiYjZiMS0zY2M5LTQwNzMtODM5My1iNzNkMjNlNzVlM2EiLCJpYXQiOjE3NTc4MjA2NTksImV4cCI6MTc1NzgyMjQ1OX0.rYreo4iwUaHXSx1_6gSs_V9XFbJdQk8Lq27XlRx-_Je1yLvVwQBmsAvQlnnU41J2WHdGcaaoi7MeEhGeZHjsRA
+Content-Type: application/json
+
+{
+  "isOpened": false
+}
+
+### Guides - 내 가이드 공개 상태 ON
+PATCH http://localhost:8080/api/guides/me/visibility
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJkMmViMzkyNSIsInR5cGUiOiJhY2Nlc3MiLCJqdGkiOiI2NzJiYjZiMS0zY2M5LTQwNzMtODM5My1iNzNkMjNlNzVlM2EiLCJpYXQiOjE3NTc4MjA2NTksImV4cCI6MTc1NzgyMjQ1OX0.rYreo4iwUaHXSx1_6gSs_V9XFbJdQk8Lq27XlRx-_Je1yLvVwQBmsAvQlnnU41J2WHdGcaaoi7MeEhGeZHjsRA
+Content-Type: application/json
+
+{
+  "isOpened": true
+}
+
 ### Reviews - 내 리뷰 조회 ALL (기본)
 GET http://localhost:8080/api/reviews/me?filter=ALL&page=0&size=10
 Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJlNjBkNTIxMSIsInR5cGUiOiJhY2Nlc3MiLCJqdGkiOiJhMjQ2MGQ1Ny1jMWI3LTRmZDktODM3ZS1hMDMxMjdhYTRiZTciLCJpYXQiOjE3NTc4MDM0OTUsImV4cCI6MTc1NzgwNTI5NX0.RHceh_sGwsNTRTouoeZp_nzJPlHgqV42XYAN3OrDNW64rbeJpdH04ZUhRgHiPNsB9IwdcmfqDj2-p4b-CrRA3g
@@ -50,4 +68,23 @@ Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJlNjBkNTIxMSIsInR5cGUiOiJhY
 ### Reviews - 무효 필터 값 (lenient: ALL로 동작)
 GET http://localhost:8080/api/reviews/me?filter=INVALID&page=0&size=10
 Authorization: Bearer ~~~
+
+### Reservations - 포인트 부족 시 신청 실패 확인 (rookie 기본 포인트 0 가정)
+POST http://localhost:8080/api/reservations
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJiYmI4NWRmMSIsInR5cGUiOiJhY2Nlc3MiLCJqdGkiOiI3YThmYjViOS05ZTA5LTQzMWMtYjQzOC0yMDU2OTA5NGY5MDQiLCJpYXQiOjE3NTc4MjAwMzUsImV4cCI6MTc1NzgyMTgzNX0.HH9wW3Qwk1fwbIs9SBL4Bh1svcUHkCZJ-6wisEGmmcJzht3kuvBtekKHJ6BOagfDGHYaLBkzDM37wBKwMTviJg
+Content-Type: multipart/form-data; boundary=WebAppBoundary
+
+--WebAppBoundary
+Content-Disposition: form-data; name="reservation"; filename="reservation.json"
+Content-Type: application/json
+
+{
+  "guideId": 3,
+  "timeUnit": "MINUTE_30",
+  "survey": {
+    "messageToGuide": "포인트 부족 테스트",
+    "preferredDate": "2030-01-01T10:00:00"
+  }
+}
+--WebAppBoundary--
 

--- a/src/test/java/coffeandcommit/crema/domain/reservation/service/ReservationServiceTest.java
+++ b/src/test/java/coffeandcommit/crema/domain/reservation/service/ReservationServiceTest.java
@@ -79,10 +79,11 @@ class ReservationServiceTest {
                 .point(20000) // Enough points for a reservation
                 .build();
 
-        // Create test guide
+        // Create test guide (공개 상태)
         testGuide = Guide.builder()
                 .id(GUIDE_ID)
                 .member(Member.builder().id("guide-member-id").build())
+                .isOpened(true)
                 .build();
 
         // Create test survey request DTO


### PR DESCRIPTION
# 🚀 What’s this PR about?

- QA 후 리팩토링

# 🛠️ What’s been done?

- 포인트 없으면 신청 자체가 안되게 제한
- 자신에게 커피챗 신청 금지
- 커피챗 공개여부 수정

# 🧪 Testing Details

- X

# 👀 Checkpoints for Reviewers

- X

# 📚 References & Resources

- X

# 🎯 Related Issues

- close#158 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 예약 생성 시 시간 단위와 보유 포인트를 사전 검증하여 부족 시 명확한 오류를 제공합니다.
  - 예약 시 본인이 자신의 가이드를 신청하는 행위를 차단합니다.
  - 예약 시 사전 설문(선호일 등) 유효성 검사를 추가하여 잘못된 입력을 차단합니다.
- 버그 수정
  - 가이드 공개 상태 변경이 즉시 저장되어 반영됩니다.
  - 관련된 명확한 오류 상태(가이드 비공개, 자기신청 금지, 유효하지 않은 설문)를 추가했습니다.
- 테스트
  - 가이드 공개 상태 ON/OFF HTTP 시나리오 및 포인트 부족 예약 실패 시나리오를 추가했습니다.
  - 로그인 테스트 데이터(닉네임)를 업데이트했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->