### PR TITLE
가이드 본인 리뷰 조회

### DIFF
--- a/src/main/java/coffeandcommit/crema/domain/guide/controller/GuideMeController.java
+++ b/src/main/java/coffeandcommit/crema/domain/guide/controller/GuideMeController.java
@@ -354,6 +354,27 @@ public class GuideMeController {
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 
+    @Operation(summary = "내 리뷰 조회", description = "가이드 본인의 리뷰 목록을 조회합니다.")
+    @GetMapping("/reviews")
+    public ResponseEntity<Response<Page<GuideReviewResponseDTO>>> getMyReviews(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            Pageable pageable
+    ) {
+        if (userDetails == null) {
+            throw new BaseException(ErrorStatus.UNAUTHORIZED);
+        }
+
+        String loginMemberId = userDetails.getMemberId();
+        Page<GuideReviewResponseDTO> result = guideMeService.getMyGuideReviews(loginMemberId, pageable);
+
+        Response<Page<GuideReviewResponseDTO>> response = Response.<Page<GuideReviewResponseDTO>>builder()
+                .message("가이드 본인 리뷰 조회 성공")
+                .data(result)
+                .build();
+
+        return ResponseEntity.ok(response);
+    }
+
     @Operation(summary = "가이드 전체 커피챗 조회", description = "가이드의 모든 상태 커피챗 예약을 조회합니다.")
     @GetMapping("/reservations/all")
     public ResponseEntity<Response<Page<GuidePendingReservationResponseDTO>>> getAllReservations(

--- a/src/main/java/coffeandcommit/crema/domain/guide/controller/GuideMeController.java
+++ b/src/main/java/coffeandcommit/crema/domain/guide/controller/GuideMeController.java
@@ -365,10 +365,15 @@ public class GuideMeController {
         }
 
         String loginMemberId = userDetails.getMemberId();
-        Page<GuideReviewResponseDTO> result = guideMeService.getMyGuideReviews(loginMemberId, pageable);
+        Pageable capped = PageRequest.of(
+                Math.max(pageable.getPageNumber(), 0),
+                Math.min(pageable.getPageSize(), 100),
+                Sort.by(Sort.Direction.DESC, "createdAt")
+        );
+        Page<GuideReviewResponseDTO> result = guideMeService.getMyGuideReviews(loginMemberId, capped);
 
         Response<Page<GuideReviewResponseDTO>> response = Response.<Page<GuideReviewResponseDTO>>builder()
-                .message("가이드 본인 리뷰 조회 성공")
+                .message("가이드본인리뷰조회성공")
                 .data(result)
                 .build();
 

--- a/src/main/java/coffeandcommit/crema/domain/guide/controller/GuideMeController.java
+++ b/src/main/java/coffeandcommit/crema/domain/guide/controller/GuideMeController.java
@@ -367,7 +367,7 @@ public class GuideMeController {
         String loginMemberId = userDetails.getMemberId();
         Pageable capped = PageRequest.of(
                 Math.max(pageable.getPageNumber(), 0),
-                Math.min(pageable.getPageSize(), 100),
+                Math.max(1, Math.min(pageable.getPageSize(), 100)),
                 Sort.by(Sort.Direction.DESC, "createdAt")
         );
         Page<GuideReviewResponseDTO> result = guideMeService.getMyGuideReviews(loginMemberId, capped);

--- a/src/main/java/coffeandcommit/crema/domain/guide/service/GuideMeService.java
+++ b/src/main/java/coffeandcommit/crema/domain/guide/service/GuideMeService.java
@@ -53,7 +53,6 @@ public class GuideMeService {
     private final ExperienceGroupRepository experienceGroupRepository;
     private final ReviewRepository reviewRepository;
     private final ReservationRepository reservationRepository;
-    private final ReservationService reservationService;
 
     /* 가이드 직무 분야 등록 */
     @Transactional

--- a/src/main/java/coffeandcommit/crema/domain/guide/service/GuideMeService.java
+++ b/src/main/java/coffeandcommit/crema/domain/guide/service/GuideMeService.java
@@ -14,6 +14,8 @@ import coffeandcommit.crema.domain.reservation.entity.Reservation;
 import coffeandcommit.crema.domain.reservation.entity.Survey;
 import coffeandcommit.crema.domain.reservation.enums.Status;
 import coffeandcommit.crema.domain.reservation.repository.ReservationRepository;
+import coffeandcommit.crema.domain.reservation.service.ReservationService;
+import coffeandcommit.crema.domain.review.entity.Review;
 import coffeandcommit.crema.domain.review.repository.ReviewRepository;
 import coffeandcommit.crema.global.common.exception.BaseException;
 import coffeandcommit.crema.global.common.exception.code.ErrorStatus;
@@ -31,6 +33,7 @@ import java.time.DayOfWeek;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -50,6 +53,7 @@ public class GuideMeService {
     private final ExperienceGroupRepository experienceGroupRepository;
     private final ReviewRepository reviewRepository;
     private final ReservationRepository reservationRepository;
+    private final ReservationService reservationService;
 
     /* 가이드 직무 분야 등록 */
     @Transactional
@@ -640,6 +644,31 @@ public class GuideMeService {
                     .preferredTimeRange(preferredTimeRange)
                     .status(reservation.getStatus())
                     .build();
+        });
+    }
+
+    /* 내(가이드 본인) 리뷰 목록 조회 */
+    @Transactional(readOnly = true)
+    public Page<GuideReviewResponseDTO> getMyGuideReviews(String loginMemberId, Pageable pageable) {
+        Guide myGuide = guideRepository.findByMember_Id(loginMemberId)
+                .orElseThrow(() -> new BaseException(ErrorStatus.GUIDE_NOT_FOUND));
+
+        Page<Review> reviewPage = reviewRepository.findByReservation_GuideOrderByCreatedAtDesc(myGuide, pageable);
+
+        List<Long> reviewIds = reviewPage.getContent().stream()
+                .map(Review::getId)
+                .toList();
+
+        List<Review> reviewsWithExperiences = reviewIds.isEmpty()
+                ? List.of()
+                : reviewRepository.findAllWithExperiencesByIdIn(reviewIds);
+
+        Map<Long, Review> reviewMap = reviewsWithExperiences.stream()
+                .collect(Collectors.toMap(Review::getId, r -> r));
+
+        return reviewPage.map(review -> {
+            Review fullReview = reviewMap.getOrDefault(review.getId(), review);
+            return GuideReviewResponseDTO.from(fullReview, review.getReservation().getMember());
         });
     }
 

--- a/src/main/java/coffeandcommit/crema/domain/guide/service/GuideMeService.java
+++ b/src/main/java/coffeandcommit/crema/domain/guide/service/GuideMeService.java
@@ -14,7 +14,6 @@ import coffeandcommit.crema.domain.reservation.entity.Reservation;
 import coffeandcommit.crema.domain.reservation.entity.Survey;
 import coffeandcommit.crema.domain.reservation.enums.Status;
 import coffeandcommit.crema.domain.reservation.repository.ReservationRepository;
-import coffeandcommit.crema.domain.reservation.service.ReservationService;
 import coffeandcommit.crema.domain.review.entity.Review;
 import coffeandcommit.crema.domain.review.repository.ReviewRepository;
 import coffeandcommit.crema.global.common.exception.BaseException;

--- a/src/main/java/coffeandcommit/crema/domain/guide/service/GuideMeService.java
+++ b/src/main/java/coffeandcommit/crema/domain/guide/service/GuideMeService.java
@@ -666,7 +666,7 @@ public class GuideMeService {
 
         return reviewPage.map(review -> {
             Review fullReview = reviewMap.getOrDefault(review.getId(), review);
-            return GuideReviewResponseDTO.from(fullReview, review.getReservation().getMember());
+            return GuideReviewResponseDTO.from(fullReview, fullReview.getReservation().getMember());
         });
     }
 

--- a/src/main/java/coffeandcommit/crema/domain/guide/service/GuideService.java
+++ b/src/main/java/coffeandcommit/crema/domain/guide/service/GuideService.java
@@ -345,7 +345,7 @@ public class GuideService {
         // Page → DTO 변환 시 경험평가 포함된 리뷰 사용
         return reviewPage.map(review -> {
             Review fullReview = reviewMap.getOrDefault(review.getId(), review);
-            return GuideReviewResponseDTO.from(fullReview, review.getReservation().getMember());
+            return GuideReviewResponseDTO.from(fullReview, fullReview.getReservation().getMember());
         });
 
     }

--- a/src/main/java/coffeandcommit/crema/global/httpTest/GuidesAndReviews.http
+++ b/src/main/java/coffeandcommit/crema/global/httpTest/GuidesAndReviews.http
@@ -7,7 +7,7 @@ POST http://localhost:8080/api/test/auth/login
 Content-Type: application/json
 
 {
-  "nickname": "guide_cdcc2689"
+  "nickname": "rookie_fe0e2657"
 }
 
 ### 아래 요청들에서 Authorization 헤더의 ~~~ 부분을 3번의 accessToken으로 교체해서 사용하세요.
@@ -88,3 +88,26 @@ Content-Type: application/json
 }
 --WebAppBoundary--
 
+### Guides - 내(가이드) 리뷰 목록 조회
+GET http://localhost:8080/api/guides/me/reviews?page=0&size=10
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIzZjNkYmZiMCIsInR5cGUiOiJhY2Nlc3MiLCJqdGkiOiI2YTM1MTkyMC0yZjk2LTRjNTUtYTY1ZC1hMGEyMDJhMDk0MWMiLCJpYXQiOjE3NTc4Mzg1MjMsImV4cCI6MTc1Nzg0MDMyM30.XIbWXGB2jpjPywlSwY9AQlwMPohf008-RlJg9rCG6ib4RwUvP9MBqxsuzoIT78NUjjGU4B9b_soKbVBljZhhwg
+
+### Guides - 특정 가이드 리뷰 조회 (공개 가이드)
+# guideId 자리에 실제 가이드 ID 입력
+GET http://localhost:8080/api/guides/3/reviews?page=0&size=10
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJjYzc1ZDJiZSIsInR5cGUiOiJhY2Nlc3MiLCJqdGkiOiIwYzE1ZmMyMy02ZjUzLTQyMDgtYmU0OS1jNTM2YzA3YzhkNTkiLCJpYXQiOjE3NTc4Mzg3NjUsImV4cCI6MTc1Nzg0MDU2NX0.Ss_n2AEtm3EVE6rmkKuY7mX2osApMMW7xBMtxTbVBlSrkmbyZufGSlWycfyxPcoLHtboDX2qDpFj5BmIzgRR2Q
+
+### Guides - 비공개 가이드 리뷰 접근 차단 확인(다른 사용자 토큰)
+# 1) 먼저 아래로 비공개 전환
+PATCH http://localhost:8080/api/guides/me/visibility
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIzZjNkYmZiMCIsInR5cGUiOiJhY2Nlc3MiLCJqdGkiOiI2YTM1MTkyMC0yZjk2LTRjNTUtYTY1ZC1hMGEyMDJhMDk0MWMiLCJpYXQiOjE3NTc4Mzg1MjMsImV4cCI6MTc1Nzg0MDMyM30.XIbWXGB2jpjPywlSwY9AQlwMPohf008-RlJg9rCG6ib4RwUvP9MBqxsuzoIT78NUjjGU4B9b_soKbVBljZhhwg
+Content-Type: application/json
+
+{
+  "isOpened": false
+}
+
+###
+# 2) 다른 사용자 토큰으로 접근 시 404/403 기대
+GET http://localhost:8080/api/guides/1/reviews?page=0&size=10
+Authorization: Bearer OTHER_USER_TOKEN


### PR DESCRIPTION
# 🚀 What’s this PR about?

- 가이드 본인의 리뷰 조회

# 🛠️ What’s been done?

- 가이드 본인의 리뷰를 조회합니다

# 🧪 Testing Details

 - getMyGuideReviews_Success                                                            
      - 가이드 본인(memberId) 기준으로 리뷰 페이지를 반환하는지 확인                     
      - 리뷰 2건을 Mock으로 반환, 작성자 닉네임 매핑 검증                                
      - reviewRepository의 페이징 조회와 경험평가 배치 조회 호출 검증                    
  - getMyGuideReviews_GuideNotFound                                                      
      - 가이드 엔티티가 없을 때 GUIDE_NOT_FOUND 예외 발생 검증                           
      - Review 조회가 호출되지 않는지 검증 

# 👀 Checkpoints for Reviewers

- X

# 📚 References & Resources

- X

# 🎯 Related Issues
- close#161 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * 가이드 본인의 리뷰를 페이지네이션으로 조회하는 엔드포인트 추가 (/api/guides/me/reviews).

* Refactor
  * 가이드 전체 예약 조회의 페이징 입력을 page/size/sortBy/direction 쿼리 파라미터로 통일하고 기본값·검증 추가.
  * 리뷰 응답 생성 시 전체로 로드된 리뷰 데이터를 우선 사용하도록 변경하여 작성자 정보 일관성 개선.

* Tests
  * 서비스 단위 테스트 추가(성공/가이드 미존재 케이스) 및 HTTP 시나리오 추가(내 리뷰, 특정 가이드 리뷰, 비공개 접근 검증).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->