### PR TITLE
[Fix] 화상통화 QuickJoin 에러 수정

### DIFF
--- a/src/main/java/coffeandcommit/crema/domain/reservation/repository/ReservationRepository.java
+++ b/src/main/java/coffeandcommit/crema/domain/reservation/repository/ReservationRepository.java
@@ -7,13 +7,19 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.QueryHints;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import jakarta.persistence.LockModeType;
+import jakarta.persistence.QueryHint;
 
 import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface ReservationRepository extends JpaRepository<Reservation, Long> {
@@ -120,4 +126,9 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
     ORDER BY r.createdAt DESC
     """)
     List<Reservation> findByGuideWithFetchJoin(@Param("guide") Guide guide);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @QueryHints(@QueryHint(name = "jakarta.persistence.lock.timeout", value = "5000"))
+    @Query("SELECT r FROM Reservation r WHERE r.id = :id")
+    Optional<Reservation> findByIdForUpdate(@Param("id") Long id);
 }

--- a/src/main/java/coffeandcommit/crema/domain/videocall/controller/VideoCallController.java
+++ b/src/main/java/coffeandcommit/crema/domain/videocall/controller/VideoCallController.java
@@ -36,6 +36,7 @@ public class VideoCallController {
             @AuthenticationPrincipal UserDetails userDetails,
             @PathVariable Long reservationId
             ) {
+        log.info("[QUICKJOIN-REQUEST] quickjoin 요청 시작 - reservationId: {}",reservationId);
         if (userDetails == null) {
             log.error("[VIDEO-CALL] 인증되지 않은 요청 - quickJoin");
             throw new RuntimeException("인증이 필요합니다");

--- a/src/main/java/coffeandcommit/crema/domain/videocall/entity/VideoSession.java
+++ b/src/main/java/coffeandcommit/crema/domain/videocall/entity/VideoSession.java
@@ -22,6 +22,7 @@ public class VideoSession extends BaseEntity {
     @Column(name = "video_session_id")
     private Long id;
 
+    @Column(unique = true)
     private String sessionName;
 
     private String sessionId;

--- a/src/main/java/coffeandcommit/crema/domain/videocall/repository/VideoSessionRepository.java
+++ b/src/main/java/coffeandcommit/crema/domain/videocall/repository/VideoSessionRepository.java
@@ -25,9 +25,14 @@ public interface VideoSessionRepository extends JpaRepository<VideoSession, Long
      * @return 잠긴 VideoSession 엔티티
      */
     @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @QueryHints(@QueryHint(name = "javax.persistence.lock.timeout", value = "3000")) // 3초 타임아웃
+    @QueryHints(@QueryHint(name = "jakarta.persistence.lock.timeout", value = "5000"))
     @Query("select vs from VideoSession vs where vs.sessionId = :sessionId")
     Optional<VideoSession> findBySessionIdForUpdate(@Param("sessionId") String sessionId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @QueryHints(@QueryHint(name = "jakarta.persistence.lock.timeout", value = "5000"))
+    @Query("select vs from VideoSession vs where vs.sessionName = :sessionName")
+    Optional<VideoSession> findBySessionNameForUpdate(@Param("sessionName") String sessionName);
 
     Optional<VideoSession> findBySessionName(String sessionName);
 }

--- a/src/main/java/coffeandcommit/crema/domain/videocall/service/VideoCallService.java
+++ b/src/main/java/coffeandcommit/crema/domain/videocall/service/VideoCallService.java
@@ -59,22 +59,20 @@ public class VideoCallService {
 
     public QuickJoinResponse quickJoin(Long reservationId, UserDetails userDetails) {
         try {
-            Reservation reservation = reservationRepository.findById(reservationId)
+            // 1. 예약을 먼저 락으로 잡음 (동시 접근 차단)
+            Reservation reservation = reservationRepository.findByIdForUpdate(reservationId)
                     .orElseThrow(() -> new SessionNotFoundException("예약 ID: " + reservationId + "를 찾을 수 없습니다"));
 
-            VideoSession session;
-            try {   //세션이 없으면 새로 만듦
-                if(reservation.getVideoSession() == null)
-                    throw new SessionNotFoundException("예약 ID " + reservation.getId() + "에 연결된 VideoSession이 없습니다");
+            // 2. 세션명 고정 생성
+            String sessionName = "reservation_" + reservation.getId();
 
-                session = videoSessionRepository
-                        .findBySessionName(reservation.getVideoSession().getSessionName())
-                        .orElseThrow(() -> new SessionNotFoundException("세션 이름: " + reservation.getVideoSession().getSessionName() + "를 찾을 수 없습니다"));
-            }catch (SessionNotFoundException e) {
-                log.info("[SESSION-QUICKJOIN] =======Exception======= \n{}", e.toString());
-                String sessionName = "reservation_" + reservation.getId();
-                session = basicVideoCallService.createVideoSession(sessionName);
-            }
+            // 3. 세션 조회 (락 사용) 및 없으면 생성
+            VideoSession session = videoSessionRepository
+                    .findBySessionNameForUpdate(sessionName)
+                    .orElseGet(() -> {
+                        log.info("[SESSION-QUICKJOIN] 세션이 없어 새로 생성: {}", sessionName);
+                        return basicVideoCallService.createVideoSession(sessionName);
+                    });
             
             String token = basicVideoCallService.joinSession(session.getSessionId(), userDetails.getUsername());
             Member member = memberRepository.findByIdAndIsDeletedFalse(userDetails.getUsername()).orElseThrow(ParticipantNotFound::new);

--- a/src/main/java/coffeandcommit/crema/domain/videocall/service/VideoCallService.java
+++ b/src/main/java/coffeandcommit/crema/domain/videocall/service/VideoCallService.java
@@ -71,7 +71,8 @@ public class VideoCallService {
                         .findBySessionName(reservation.getVideoSession().getSessionName())
                         .orElseThrow(() -> new SessionNotFoundException("세션 이름: " + reservation.getVideoSession().getSessionName() + "를 찾을 수 없습니다"));
             }catch (SessionNotFoundException e) {
-                String sessionName = "reservation_" + reservation.getId() + "_" + reservation.getReservedAt();
+                log.info("[SESSION-QUICKJOIN] =======Exception======= \n{}", e.toString());
+                String sessionName = "reservation_" + reservation.getId();
                 session = basicVideoCallService.createVideoSession(sessionName);
             }
             


### PR DESCRIPTION
# 🚀 What’s this PR about?

- 화상통화 QuickJoin 에러 수정
# 🛠️ What’s been done?

- name 생성시 null 위험 있던 것 제외
- Lock 추가하여 race condition 해소

# 🧪 Testing Details

- X

# 👀 Checkpoints for Reviewers

- X

# 📚 References & Resources

- X

# 🎯 Related Issues


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 버그 수정
  * 화상통화 빠른 참가 시 간헐적 실패와 중복 세션 생성 문제를 감소시켜 연결 안정성을 향상했습니다.
  * 세션 이름을 예약 ID 기반으로 일관화해 재접속 및 토큰 발급 오류를 줄였습니다.
  * 세션 이름 중복을 방지하는 제한을 추가해 예기치 않은 충돌을 최소화했습니다.
* 작업
  * 빠른 참가 요청의 예약 ID 로깅을 추가해 문제 추적성을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->