### PR TITLE
가이드 본인 커피챗, 경험평가

### DIFF
--- a/src/main/java/coffeandcommit/crema/domain/guide/controller/GuideMeController.java
+++ b/src/main/java/coffeandcommit/crema/domain/guide/controller/GuideMeController.java
@@ -380,6 +380,46 @@ public class GuideMeController {
         return ResponseEntity.ok(response);
     }
 
+    @Operation(summary = "내 커피챗 조회", description = "가이드 본인의 커피챗 정보를 조회합니다.")
+    @GetMapping("/coffeechats")
+    public ResponseEntity<Response<GuideCoffeeChatResponseDTO>> getMyCoffeeChat(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        if (userDetails == null) {
+            throw new BaseException(ErrorStatus.UNAUTHORIZED);
+        }
+
+        String loginMemberId = userDetails.getMemberId();
+        GuideCoffeeChatResponseDTO result = guideMeService.getMyCoffeeChat(loginMemberId);
+
+        Response<GuideCoffeeChatResponseDTO> response = Response.<GuideCoffeeChatResponseDTO>builder()
+                .message("가이드 본인 커피챗 조회 성공")
+                .data(result)
+                .build();
+
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "내 경험 평가 조회", description = "가이드 본인의 경험 평가(따봉 비율)를 조회합니다.")
+    @GetMapping("/experience-evaluations")
+    public ResponseEntity<Response<List<GuideExperienceEvaluationResponseDTO>>> getMyExperienceEvaluations(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        if (userDetails == null) {
+            throw new BaseException(ErrorStatus.UNAUTHORIZED);
+        }
+        String loginMemberId = userDetails.getMemberId();
+
+        List<GuideExperienceEvaluationResponseDTO> result = guideMeService.getMyExperienceEvaluations(loginMemberId);
+
+        Response<List<GuideExperienceEvaluationResponseDTO>> response = Response.<List<GuideExperienceEvaluationResponseDTO>>builder()
+                .message("가이드 본인 경험 평가 조회 성공")
+                .data(result)
+                .build();
+
+        return ResponseEntity.ok(response);
+    }
+
     @Operation(summary = "가이드 전체 커피챗 조회", description = "가이드의 모든 상태 커피챗 예약을 조회합니다.")
     @GetMapping("/reservations/all")
     public ResponseEntity<Response<Page<GuidePendingReservationResponseDTO>>> getAllReservations(

--- a/src/main/java/coffeandcommit/crema/global/httpTest/GuidesAndReviews.http
+++ b/src/main/java/coffeandcommit/crema/global/httpTest/GuidesAndReviews.http
@@ -7,7 +7,7 @@ POST http://localhost:8080/api/test/auth/login
 Content-Type: application/json
 
 {
-  "nickname": "rookie_fe0e2657"
+  "nickname": "guide_1d902961"
 }
 
 ### 아래 요청들에서 Authorization 헤더의 ~~~ 부분을 3번의 accessToken으로 교체해서 사용하세요.
@@ -92,6 +92,10 @@ Content-Type: application/json
 GET http://localhost:8080/api/guides/me/reviews?page=0&size=10
 Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIzZjNkYmZiMCIsInR5cGUiOiJhY2Nlc3MiLCJqdGkiOiI2YTM1MTkyMC0yZjk2LTRjNTUtYTY1ZC1hMGEyMDJhMDk0MWMiLCJpYXQiOjE3NTc4Mzg1MjMsImV4cCI6MTc1Nzg0MDMyM30.XIbWXGB2jpjPywlSwY9AQlwMPohf008-RlJg9rCG6ib4RwUvP9MBqxsuzoIT78NUjjGU4B9b_soKbVBljZhhwg
 
+### Guides - 내(가이드) 커피챗 조회
+GET http://localhost:8080/api/guides/me/coffeechats
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiI5OTMxZTliYiIsInR5cGUiOiJhY2Nlc3MiLCJqdGkiOiI1MmMzZWFmMC1jY2Q3LTQxMTItYTQ2Yi01NzQ5YzUzMWU1OGYiLCJpYXQiOjE3NTc4NTQ0MzMsImV4cCI6MTc1Nzg1NjIzM30.ppYa8D_YdiSCMawLFCAlUYKkqTrPBAj5BioqH_D_c2Pasad0aKqbslSNu2uXGo0d4F6ZpPKI7CMKCwVQaVSOtg
+
 ### Guides - 특정 가이드 리뷰 조회 (공개 가이드)
 # guideId 자리에 실제 가이드 ID 입력
 GET http://localhost:8080/api/guides/3/reviews?page=0&size=10
@@ -111,3 +115,7 @@ Content-Type: application/json
 # 2) 다른 사용자 토큰으로 접근 시 404/403 기대
 GET http://localhost:8080/api/guides/1/reviews?page=0&size=10
 Authorization: Bearer OTHER_USER_TOKEN
+
+### Guides - 내(가이드) 경험 평가 조회
+GET http://localhost:8080/api/guides/me/experience-evaluations
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJkMjczMGE2NyIsInR5cGUiOiJhY2Nlc3MiLCJqdGkiOiIxMjVkZjBkMS1jODBlLTRiNWUtYjRjOC1mNmZjODk4N2Y0ZjciLCJpYXQiOjE3NTc4NTUwOTAsImV4cCI6MTc1Nzg1Njg5MH0.XH1g1pdcqWrYLmxH4qRAaSNFQW5UiVzUrbsIQayl06xvoDsWfNOLh3gXAIC2Xx0YIZKfJkMXGRqVTQadxhqhsA


### PR DESCRIPTION
# 🚀 What’s this PR about?

- 가이드 본인 커피챗, 경험평가

# 🛠️ What’s been done?

- 가이드 본인 커피챗 정보 조회
- 가이드 본인 경험평가 조회
- 관련 테스트 코드

# 🧪 Testing Details

- getMyCoffeeChat - 성공: 가이드 본인 커피챗 상세 조회
- getMyCoffeeChat - 실패: 가이드 없음
- getMyExperienceEvaluations - 성공: 각 경험의 추천 비율 계산
- getMyExperienceEvaluations - 실패: 가이드 없음


# 👀 Checkpoints for Reviewers

- X

# 📚 References & Resources

- X

# 🎯 Related Issues
- close#168 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 가이드 전용 “내 커피챗” 및 “내 경험 평가” 조회 API 추가. 로그인한 가이드는 자신의 커피챗 요약(태그, 평균 평점, 리뷰 수, 경험 정보)과 경험 그룹별 평가 비율을 확인할 수 있습니다. 인증이 필요합니다.
- Tests
  - 새로운 가이드 자기조회 API에 대한 HTTP 시나리오와 서비스 단위 테스트 추가로 성공/예외 경로 검증을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->